### PR TITLE
Feature/search refactor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,5 +65,5 @@ USER 1000:1000
 
 ENTRYPOINT ["/rails/bin/docker-entrypoint"]
 
-EXPOSE 80
-CMD ["./bin/thrust", "./bin/rails", "server"]
+EXPOSE 8080
+CMD ["./bin/thrust", "./bin/rails", "server", "-b", "0.0.0.0", "-p", "8080"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,4 +66,4 @@ USER 1000:1000
 ENTRYPOINT ["/rails/bin/docker-entrypoint"]
 
 EXPOSE 8080
-CMD ["./bin/thrust", "./bin/rails", "server", "-b", "0.0.0.0", "-p", "8080"]
+CMD ["./bin/rails", "server", "-b", "0.0.0.0", "-p", "8080"]

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -4,17 +4,10 @@ class BooksController < ApplicationController
   before_action :authorize_book, only: [ :edit, :update, :destroy ]
 
   def index
-    unless user_signed_in?
-      @books = sample_books
-      return
-    end
+    return @books = sample_books unless user_signed_in?
 
     books = current_user.books
-    unless books.exists?
-      @no_books = true
-      @books = sample_books
-      return
-    end
+    return @books = sample_books.tap { @no_books = true } unless books.exists?
 
     @books = books.order(created_at: :desc)
   end

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -4,18 +4,19 @@ class BooksController < ApplicationController
   before_action :authorize_book, only: [ :edit, :update, :destroy ]
 
   def index
-    @books =
-      if user_signed_in?
-        books = current_user.books.order(created_at: :desc)
-        if books.exists?
-          books
-        else
-          @no_books = true
-          sample_books
-        end
-      else
-        sample_books
-      end
+    unless user_signed_in?
+      @books = sample_books
+      return
+    end
+
+    books = current_user.books
+    unless books.exists?
+      @no_books = true
+      @books = sample_books
+      return
+    end
+
+    @books = books.order(created_at: :desc)
   end
 
   def show

--- a/app/controllers/explore_controller.rb
+++ b/app/controllers/explore_controller.rb
@@ -7,7 +7,7 @@ class ExploreController < ApplicationController
       if @scope == "mine"
         search_my_books(@query)
       else
-        search_public_books(@query)
+        search_public_memos(@query)
       end
   end
 
@@ -17,26 +17,22 @@ class ExploreController < ApplicationController
     return Book.none unless user_signed_in?
 
     books = current_user.books.includes(:memos)
-
     return books unless query.present?
 
-    # 検索条件に一致する book_id をすべて集めて結合
     title_author_ids = books.search_by_title_and_author(query).pluck(:id)
     memo_book_ids = current_user.memos.search_by_content(query).pluck(:book_id)
 
     Book.where(id: (title_author_ids + memo_book_ids).uniq)
   end
 
-  def search_public_books(query)
-    public_memo_scope = Memo.where(visibility: Memo::VISIBILITY[:public_site])
-    book_ids = public_memo_scope.pluck(:book_id).uniq
-    books = Book.where(id: book_ids)
+  def search_public_memos(query)
+    scope = Memo.where(visibility: Memo::VISIBILITY[:public_site]).includes(:book, :user)
 
-    return books unless query.present?
+    return scope unless query.present?
 
-    title_author_ids = books.search_by_title_and_author(query).pluck(:id)
-    memo_book_ids = public_memo_scope.search_by_content(query).pluck(:book_id)
+    book_ids = Book.search_by_title_and_author(query).pluck(:id)
+    memo_ids = scope.search_by_content(query).pluck(:id)
 
-    Book.where(id: (title_author_ids + memo_book_ids).uniq)
+    scope.where(id: memo_ids).or(scope.where(book_id: book_ids))
   end
 end

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -13,20 +13,10 @@
   </div>
 <% end %>
 
-<% if current_user && !@no_books %>
+<% if user_signed_in? && !@no_books %>
   <!-- 検索窓 -->
-  <%= form_with url: explore_path, method: :get, local: true, class: "my-2 my-md-3 d-flex justify-content-center" do %>
-    <%= hidden_field_tag :scope, "mine" %>
-    <div class="input-group shadow-sm bg-light rounded-2 overflow-hidden" style="max-width: 480px; width: 100%;">
-      <span class="input-group-text bg-light border-0 ps-3">
-        <i class="bi bi-search text-muted"></i>
-      </span>
-      <%= text_field_tag :q, params[:q], placeholder: "自分の本やメモを検索", class: "form-control form-control-lg border-0 bg-light" %>
-      <button type="submit" class="btn btn-primary border-0 px-4">
-        検索
-      </button>
-    </div>
-  <% end %>
+    <%= render "shared/search_bar", scope: "mine", placeholder: "自分の本やメモを検索",
+                            form_class: "my-2 my-md-3 d-flex justify-content-center" %>
   <!-- PC表示用 -->
   <div class="d-none d-xxl-block">
     <%= render partial: "bookshelf/kino_books_grid", locals: { books: @books } %>
@@ -38,11 +28,7 @@
 <% end %>
 
 <% if @no_books || !user_signed_in? %>
-  <div class="books-grid-iphone">
-    <% @books.each do |book| %>
-      <%= image_tag asset_path(book.title), alt: book.title, class: "img-fluid rounded" %>
-    <% end %>
-  </div>
+  <%= render partial: "bookshelf/sample_books", locals: { books: @books } %>
 <% end %>
 
 <% if !user_signed_in? %>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -1,4 +1,4 @@
-<% if @not_logged_in %>
+<% if !user_signed_in? %>
   <div class="alert alert-info text-center">
     こちらはサンプル表示です。自分の本棚を作成するには、ログイン・アカウント登録が必要です。
   </div>
@@ -37,7 +37,7 @@
   </div>
 <% end %>
 
-<% if @no_books || @not_logged_in %>
+<% if @no_books || !user_signed_in? %>
   <div class="books-grid-iphone">
     <% @books.each do |book| %>
       <%= image_tag asset_path(book.title), alt: book.title, class: "img-fluid rounded" %>
@@ -45,7 +45,7 @@
   </div>
 <% end %>
 
-<% if @not_logged_in %>
+<% if !user_signed_in? %>
   <div class="registration-cta text-center mt-5 text-dark fw-bold  big-shoulders-inline-bold">
     <h4>あなたの読書体験をもっと豊かに</h4>
     <p>Bokriumで読書メモを管理し、知識を整理しましょう</p>

--- a/app/views/bookshelf/_sample_books.html.erb
+++ b/app/views/bookshelf/_sample_books.html.erb
@@ -1,0 +1,5 @@
+  <div class="books-grid-iphone">
+    <% books.each do |book| %>
+      <%= image_tag asset_path(book.title), alt: book.title, class: "img-fluid rounded" %>
+    <% end %>
+  </div>

--- a/app/views/explore/index.html.erb
+++ b/app/views/explore/index.html.erb
@@ -1,11 +1,19 @@
-<div class="container mt-4">
-  <div id="search-box"></div>
-</div>
+<div class="container text-center my-4">
   <% if @results.any? %>
-    <h2 class="mt-4 mb-3 container text-center">検索結果（<%= @results.size %>件）</h2>
+    <h2 class="mb-3 ">検索結果（<%= @results.size %>件）</h2>
 
+    <% case params[:scope] %>
+    <% when "public" %>
+      <div id="memo-grid" class="row row-cols-1 row-cols-md-3 g-4">
+        <%= render partial: "public_bookshelf/public_card", collection: @results, as: :memo %>
+      </div>
+    <% when "mine" %>
       <%= render partial: "bookshelf/kino_books_grid", locals: { books: @results } %>
+    <% else %>
+      <p class="text-center text-warning">スコープが不正です</p>
+    <% end %>
 
   <% else %>
-    <p class="text-center text-muted  mt-4">該当する書籍が見つかりませんでした。</p>
+    <p class="text-muted mt-4">該当する書籍が見つかりませんでした。</p>
   <% end %>
+</div>

--- a/app/views/explore/suggestions.html.erb
+++ b/app/views/explore/suggestions.html.erb
@@ -1,2 +1,0 @@
-<h1>Explore#suggestions</h1>
-<p>Find me in app/views/explore/suggestions.html.erb</p>

--- a/app/views/public_bookshelf/index.html.erb
+++ b/app/views/public_bookshelf/index.html.erb
@@ -1,21 +1,9 @@
 <div class="container text-center my-4">
   <% if @others_random_memo && @others_random_memo.book && @others_random_memo.user %>
   <div class="container">
-    <h2 class="text-center mb-4">みんなの本棚</h2>
-
-    <%= form_with url: explore_path, method: :get, local: true, class: "mb-md-5 mb-2 d-flex justify-content-center" do %>
-      <%= hidden_field_tag :scope, "public" %>
-
-      <div class="input-group shadow-sm bg-light rounded overflow-hidden" style="max-width: 480px; width: 100%;">
-        <span class="input-group-text bg-light border-0 ps-3">
-          <i class="bi bi-search text-muted"></i>
-        </span>
-        <%= text_field_tag :q, params[:q], placeholder: "タイトル・著者・メモ", class: "form-control form-control-lg border-0 bg-light" %>
-        <button type="submit" class="btn btn-primary border-0 px-4">
-          検索
-        </button>
-      </div>
-    <% end %>
+    <!-- 検索窓 -->
+    <%= render "shared/search_bar", scope: "public", placeholder: "タイトル・著者・メモ",
+                              form_class: "mb-md-5 mb-2 d-flex justify-content-center" %>
 
     <div id="memo-grid" class="row row-cols-1 row-cols-md-3 g-4">
       <%= render partial: "public_bookshelf/public_card", collection: @random_memos, as: :memo %>

--- a/app/views/shared/_search_bar.html.erb
+++ b/app/views/shared/_search_bar.html.erb
@@ -1,0 +1,13 @@
+<%= form_with url: explore_path, method: :get, local: true, class: local_assigns[:form_class] || "my-3 d-flex justify-content-center" do %>
+  <%= hidden_field_tag :scope, scope %>
+
+  <div class="input-group shadow-sm bg-light rounded-2 overflow-hidden" style="max-width: 480px; width: 100%;">
+    <span class="input-group-text bg-light border-0 ps-3">
+      <i class="bi bi-search text-muted"></i>
+    </span>
+    <%= text_field_tag :q, params[:q], placeholder: placeholder || "検索", class: "form-control form-control-lg border-0 bg-light" %>
+    <button type="submit" class="btn btn-primary border-0 px-4">
+      検索
+    </button>
+  </div>
+<% end %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,7 +22,7 @@ Rails.application.configure do
   # config.asset_host = "http://assets.example.com"
 
   # Store uploaded files in Tigris Global Object Storage (see config/storage.yml for options).
-  config.active_storage.service = :tigris
+  config.active_storage.service = :amazon
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   config.assume_ssl = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -73,11 +73,11 @@ Rails.application.configure do
   # Only use :id for inspections in production.
   config.active_record.attributes_for_inspect = [ :id ]
   # fly.io対策?
-  # config.hosts.clear
+  config.hosts.clear
   # config.assets.js_compressor = nil
 end
 
-Rails.application.routes.default_url_options = {
-  protocol: "https",
-  host: "bokriumm-5c4e18c57830.herokuapp.com"
-}
+# Rails.application.routes.default_url_options = {
+#   protocol: "https",
+#   host: "bokriumm-5c4e18c57830.herokuapp.com"
+# }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get "/up", to: proc { [ 200, {}, [ "OK" ] ] }
   get "explore/index"
   get "explore/suggestions"
   get "search", to: "search#index", as: :search_books
@@ -28,7 +29,6 @@ Rails.application.routes.draw do
   get "/explore", to: "explore#index", as: :explore
 
   root "welcome#index"
-  get "/up", to: proc { [ 200, {}, [ "OK" ] ] }
 end
 
 # 公式リファレンス https://guides.rubyonrails.org/routing.html

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -21,9 +21,9 @@ amazon:
   region: <%= ENV["AWS_DEFAULT_REGION"] %>
   bucket: <%= ENV["S3_BUCKET_NAME"] %>
 
-tigris:
-  service: S3
-  access_key_id: <%= ENV["AWS_ACCESS_KEY_ID"] %>
-  secret_access_key: <%= ENV["AWS_SECRET_ACCESS_KEY"] %>
-  endpoint: <%= ENV["AWS_ENDPOINT_URL_S3"] %>
-  bucket: <%= ENV["BUCKET_NAME"] %>
+# tigris:
+#   service: S3
+#   access_key_id: <%= ENV["AWS_ACCESS_KEY_ID"] %>
+#   secret_access_key: <%= ENV["AWS_SECRET_ACCESS_KEY"] %>
+#   endpoint: <%= ENV["AWS_ENDPOINT_URL_S3"] %>
+#   bucket: <%= ENV["BUCKET_NAME"] %>

--- a/fly.toml
+++ b/fly.toml
@@ -3,7 +3,7 @@
 # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
 #
 
-app = 'bokriumm'
+app = 'Bokrium'
 primary_region = 'nrt'
 console_command = '/rails/bin/rails console'
 

--- a/fly.toml
+++ b/fly.toml
@@ -3,7 +3,7 @@
 # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
 #
 
-app = 'Bokrium'
+app = 'bokrium'
 primary_region = 'nrt'
 console_command = '/rails/bin/rails console'
 


### PR DESCRIPTION
検索機能の再設計とホスティング移行に伴う対応

概要

これまで ElasticSearch + Searchkick を使っていた全文検索機能を見直し、軽量かつ導入が容易な pg_search ベースの構成に切り替えました。それに伴い、インフラも Heroku から Fly.io に移行し、アプリケーションのリポジトリも bokriumm から新たに整理された構成に変更しています。

このブランチで対応したこと
- ExploreController の再実装（pg_search による自前スコープ検索）
- 自分の本棚 / 公開メモの検索を切り替えるための scope パラメータ導入
- 結果表示の出し分け、検索フォームのパーシャル化など、UIの整理
- 古いビューや使われていなかったコードの削除・整理