### PR TITLE
Style: headerとfooterならびfilter iconsのビューを改善

### DIFF
--- a/app/assets/stylesheets/_color.scss
+++ b/app/assets/stylesheets/_color.scss
@@ -16,6 +16,13 @@
 
   background: #2d2d2de3;
   background: #1f1d14e3;
+  background-color:rgb(142, 168, 173);
+
+}
+
+.footer-color {
+
+  background-color:rgba(221, 231, 233, 0.662);
 }
 
 .rhodia-gray-with-paper {

--- a/app/assets/stylesheets/_footer.scss
+++ b/app/assets/stylesheets/_footer.scss
@@ -4,19 +4,16 @@
   letter-spacing: 0.02em;
 }
 
+.rhodia-paper-header {
+  font-family: "Georgia", "游明朝", serif;
+}
+
 .footer-link {
-  font-size: 1rem;
-  text-decoration: none;
-  margin-left: 1.5rem;
-  margin-right: 1.5rem;
-  transition: color 0.2s;
-}
-.footer-link:hover {
-  color: #000 !important;
-  text-decoration: underline;
-}
-@media (max-width: 576px) {
-  .footer-link {
-    font-size: 0.7rem;
+  color: #6c757d; // 通常の Bootstrap の text-secondary 色
+  transition: color 0.2s ease;
+
+  &:hover {
+    color: #212529; // Bootstrapの text-body 色と同等（濃い黒寄り）
+    text-decoration: underline;
   }
 }

--- a/app/assets/stylesheets/_my_bookshelf_pc.scss
+++ b/app/assets/stylesheets/_my_bookshelf_pc.scss
@@ -3,7 +3,7 @@
   flex-direction: column;
   gap: 64px;
   padding: 2rem 1rem;
-  background-color: #f0f4f3;
+  background-color:rgba(221, 231, 233, 0.148);
 }
 
 .shelf {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -68,3 +68,54 @@ body {
   height: 1em;
   vertical-align: -0.125em;
 }
+
+.filter-controls {
+  background-color: #e0e7f0;
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.06);
+  padding: 0.75rem 1.5rem;
+  display: inline-flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.filter-controls {
+  backdrop-filter: blur(4px);
+  background-color: rgba(228, 236, 237, 0.825);
+  border: 1px solid #dee2e6;
+  transition: box-shadow 0.2s ease;
+
+  &:hover {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+  }
+}
+
+.btn-icon {
+  background: transparent;
+  border: none;
+  padding: 0.25rem;
+  transition: transform 0.2s ease;
+
+  &:hover .icon-refined {
+    transform: scale(1.15);
+    color: #343a40;
+  }
+}
+
+.icon-refined {
+  font-size: 1.25rem; // 約20px（やや小ぶり）
+  color: #6c757d; // text-secondary相当
+  transition: color 0.2s ease, transform 0.2s ease;
+}
+
+.tag-btn {
+  opacity: 0.85;
+  transition: all 0.2s ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+
+  &:hover {
+    opacity: 1;
+    transform: translateY(-1px);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+  }
+}

--- a/app/views/books/_sort_controls.html.erb
+++ b/app/views/books/_sort_controls.html.erb
@@ -1,15 +1,14 @@
-<!-- ソートリンク群 -->
-<div class="mt-2" data-ui-toggle-target="content">
-  <div class="btn-group" role="group" aria-label="Sort options">
+<div class="d-flex justify-content-center">
+  <div class="d-flex flex-wrap gap-2 px-3 py-2 bg-white border rounded-pill shadow-sm align-items-center">
     <%= link_to "新しい順", books_path(tag: filtered_tag, sort: nil),
-          class: "btn btn-outline-secondary btn-sm #{'active' if current_sort.blank?}" %>
+          class: "btn btn-outline-secondary btn-sm rounded-pill #{'active' if current_sort.blank?}" %>
     <%= link_to "古い順", books_path(tag: filtered_tag, sort: "oldest"),
-          class: "btn btn-outline-secondary btn-sm #{'active' if current_sort == 'oldest'}" %>
+          class: "btn btn-outline-secondary btn-sm rounded-pill #{'active' if current_sort == 'oldest'}" %>
     <%= link_to "タイトル順", books_path(tag: filtered_tag, sort: "title_asc"),
-          class: "btn btn-outline-secondary btn-sm #{'active' if current_sort == 'title_asc'}" %>
+          class: "btn btn-outline-secondary btn-sm rounded-pill #{'active' if current_sort == 'title_asc'}" %>
     <%= link_to "著者順", books_path(tag: filtered_tag, sort: "author_asc"),
-          class: "btn btn-outline-secondary btn-sm #{'active' if current_sort == 'author_asc'}" %>
+          class: "btn btn-outline-secondary btn-sm rounded-pill #{'active' if current_sort == 'author_asc'}" %>
     <%= link_to "メモ更新順", books_path(tag: filtered_tag, sort: "latest_memo"),
-          class: "btn btn-outline-secondary btn-sm #{'active' if current_sort == 'latest_memo'}" %>
+          class: "btn btn-outline-secondary btn-sm rounded-pill #{'active' if current_sort == 'latest_memo'}" %>
   </div>
 </div>

--- a/app/views/books/_tag_filter.html.erb
+++ b/app/views/books/_tag_filter.html.erb
@@ -1,10 +1,14 @@
-<% current_user.tags.each do |tag| %>
-  <span
-    role="button"
-    class="badge rounded-pill mx-1 mb-2 tag-btn"
-    data-action="click->tag-toggle#toggle"
-    data-tag-toggle-name-param="<%= tag.name %>"
-    style="background-color: <%= tag.color %>; color: white; opacity: 0.5; cursor: pointer;">
-    <%= tag.name %>
-  </span>
-<% end %>
+<div class="d-flex justify-content-center">
+  <div class="d-flex flex-wrap gap-2 px-3 py-2 bg-white border rounded-pill shadow-sm align-items-center">
+    <% current_user.tags.each do |tag| %>
+      <span
+        role="button"
+        class="badge rounded-pill tag-btn text-white"
+        data-action="click->tag-toggle#toggle"
+        data-tag-toggle-name-param="<%= tag.name %>"
+        style="background-color: <%= tag.color %>; cursor: pointer;">
+        <%= tag.name %>
+      </span>
+    <% end %>
+  </div>
+</div>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -16,21 +16,28 @@
 <% if user_signed_in? && !@no_books %>
   <!-- 検索・タグ・ソートトグル 横並び -->
   <!-- 📦 トップの3アイコンボタンを横並びに固定 -->
-  <div class="d-flex justify-content-center gap-3 mb-2">
-    <!-- 各トグルボタン（アイコン）だけ表示）-->
-    <button class="btn" data-bs-toggle="collapse" data-bs-target="#searchCollapse" aria-expanded="false">
-      <i class="bi bi-search fs-4"></i>
+ <!-- 📦 トップの3アイコンボタン（洗練版） -->
+<div class="d-flex justify-content-center mt-3 mb-3">
+  <div class="filter-controls border rounded-pill shadow-sm px-4 py-2 d-flex align-items-center gap-3">
+    <!-- 検索 -->
+    <button class="btn btn-icon" data-bs-toggle="collapse" data-bs-target="#searchCollapse" aria-expanded="false">
+      <i class="bi bi-search icon-refined"></i>
     </button>
-    <button class="btn" data-bs-toggle="collapse" data-bs-target="#sortCollapse" aria-expanded="false">
-      <i class="bi bi-filter fs-4"></i>
+
+    <!-- ソート -->
+    <button class="btn btn-icon" data-bs-toggle="collapse" data-bs-target="#sortCollapse" aria-expanded="false">
+      <i class="bi bi-filter icon-refined"></i>
     </button>
-    <button class="btn" data-bs-toggle="collapse" data-bs-target="#tagCollapse" aria-expanded="false">
-      <i class="bi bi-tags fs-4"></i>
+
+    <!-- タグ -->
+    <button class="btn btn-icon" data-bs-toggle="collapse" data-bs-target="#tagCollapse" aria-expanded="false">
+      <i class="bi bi-tags icon-refined"></i>
     </button>
   </div>
+</div>
 
   <!-- 📦 下の行：トグルで展開される内容（初期は非表示） -->
-  <div class="text-center">
+  <div class="">
     <!-- 検索フォーム -->
     <div class="collapse mb-2" id="searchCollapse">
       <%= render "shared/search_bar", scope: "mine", placeholder: "自分の本やメモを検索" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -44,7 +44,9 @@
         <span class="visually-hidden">Loading...</span>
       </div>
     </div>
-    <%= yield %>
+     <main style="flex: 1;">
+      <%= yield %>
+    </main>
     <%= render "shared/footer" %>
     <%= turbo_frame_tag "modal" %>
   </body>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,19 +1,10 @@
-<footer class="footer rhodia-gray border-top py-4 mt-auto">
+<footer class="border-top rhodia-paper-header py-3 mt-5">
   <div class="container text-center">
-    <div>
-      <%= link_to "Bokrium", root_path, class: "big-shoulders-inline-bold logo-footer text-light", style: "font-size: 2.5rem; text-decoration: none;" %>
+    <div class="d-flex flex-wrap justify-content-center gap-4 small text-secondary">
+      <%= link_to "利用規約", root_path, class: "text-decoration-none footer-link" %>
+      <%= link_to "プライバシーポリシー", root_path, class: "text-decoration-none footer-link" %>
+      <%= link_to "お問い合わせ", root_path, class: "text-decoration-none footer-link" %>
     </div>
-
-    <div class="d-flex justify-content-center flex-nowrap gap-3 mt-2 mb-0 small overflow-x-auto" style="list-style: none; padding-left: 0;">
-      <div class="text-nowrap">
-        <%= link_to "利用規約", root_path, class: "footer-link text-white-50" %>
-      </div>
-      <div class="text-nowrap">
-        <%= link_to "プライバシーポリシー", root_path, class: "footer-link text-white-50" %>
-      </div>
-      <div class="text-nowrap">
-        <%= link_to "お問い合わせ", root_path, class: "footer-link text-white-50" %>
-      </div>
-    </div>
+    <div class="mt-2 small text-muted">&copy; <%= Time.current.year %> Bokrium. All rights reserved.</div>
   </div>
 </footer>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,83 +1,33 @@
-<nav class="navbar navbar-expand-lg navbar-dark rhodia-gray shadow-sm">
-  <div class="container-fluid px-md-5 px-4">
+<nav class="navbar shadow-sm border-bottom rhodia-paper-header py-2 px-3">
+  <div class="container-fluid d-flex justify-content-between align-items-center" style="min-height: 72px;">
 
-    <!-- PC用: 大きなロゴ -->
-    <%= link_to "Bokrium", root_path,
-          class: "text-light navbar-brand fw-bold text-primary big-shoulders-inline-bold logo-link d-none d-lg-block",
-          style: "font-size: 3.5rem;" %>
+    <!-- 左：ロゴ -->
+    <%= link_to root_path, class: "navbar-brand fw-bold text-dark big-shoulders-inline-bold", style: "font-size: 1.8rem; letter-spacing: 0.03em;" do %>
+      Bokrium
+    <% end %>
 
-    <!-- ✅ スマホ専用ナビ（lg未満で表示） -->
-    <div class="d-flex d-lg-none justify-content-between align-items-center w-100 px-２ py-3" style="min-height: 72px;">
-      <!-- 左: 大きめロゴ -->
-      <%= link_to root_path, class: "text-light text-decoration-none fw-bold big-shoulders-inline-bold", style: "font-size: 2.2rem;" do %>
-        Bokrium
+    <!-- 中央：ナビアイコン -->
+    <div class="d-flex align-items-center justify-content-center gap-5">
+      <%= link_to books_path, class: "text-dark" do %>
+        <i data-lucide="library-big" style="width: 24px; height: 24px;"></i>
       <% end %>
-
-      <!-- 中央: ナビアイコン（やや大きく、gapもゆったり） -->
-      <div class="d-flex justify-content-center gap-4 px-2">
-        <%= link_to books_path, class: "text-light" do %>
-          <i data-lucide="library-big" style="width: 32px; height: 32px; stroke-width: 1"></i>
-        <% end %>
-        <%= link_to search_books_path, class: "text-light" do %>
-          <i data-lucide="search" style="width: 32px; height: 32px; stroke-width: 1.25"></i>
-        <% end %>
-        <%= link_to public_bookshelf_index_path, class: "text-light" do %>
-          <i data-lucide="users" style="width: 32px; height: 32px; stroke-width: 1.25"></i>
-        <% end %>
-      </div>
-
-      <!-- 右: アバター -->
-      <div class="ps-2">
-        <% if user_signed_in? %>
-          <%= link_to user_path(current_user) do %>
-            <%= image_tag user_avatar(current_user, size: 40), alt: current_user.name, class: "rounded-circle", style: "width: 36px; height: 36px; object-fit: cover;" %>
-          <% end %>
-        <% else %>
-          <%= link_to new_user_session_path, class: "btn btn-sm btn-primary" do %>
-            ログイン
-          <% end %>
-        <% end %>
-      </div>
+      <%= link_to search_books_path, class: "text-dark" do %>
+        <i data-lucide="search" style="width: 24px; height: 24px;"></i>
+      <% end %>
+      <%= link_to public_bookshelf_index_path, class: "text-dark" do %>
+        <i data-lucide="users" style="width: 24px; height: 24px;"></i>
+      <% end %>
     </div>
-    <!-- ナビゲーションとユーザー -->
-    <div class="navbar-collapse justify-content-between d-none d-lg-block">
-      <ul class="navbar-nav text-end mx-auto mb-2 mb-lg-0" style="font-size: 1.25rem;">
-        <li class="nav-item">
-          <%= nav_link_to root_path do %>
-            <i data-lucide="home" class="me-2" style="width: 20px; height: 20px; stroke-width: 1.75;"></i>
-            <%= t('nav.home', default: 'ホーム') %>
-          <% end %>
-        </li>
-        <li class="nav-item">
-          <%= nav_link_to books_path do %>
-            <i data-lucide="library" class="me-2" style="width: 20px; height: 20px;"></i>
-            <%= t('nav.service', default: 'じぶんの本棚') %>
-          <% end %>
-        </li>
-        <li class="nav-item">
-          <%= nav_link_to search_books_path do %>
-            <i data-lucide="search" class="me-2" style="width: 20px; height: 20px;"></i>
-            <%= t('nav.portfolio', default: '書籍検索') %>
-          <% end %>
-        </li>
-        <li class="nav-item">
-          <%= nav_link_to public_bookshelf_index_path do %>
-            <i data-lucide="users" class="me-2" style="width: 20px; height: 20px;"></i>
-            <%= t('nav.price', default: 'みんなの本棚') %>
-          <% end %>
-        </li>
-      </ul>
-      <!-- PC用：ユーザーアイコンまたは認証ボタン -->
-      <div class="d-none d-lg-flex align-items-center gap-2 ms-lg-3">
-        <% if user_signed_in? %>
-          <%= link_to user_path(current_user) do %>
-            <%= image_tag user_avatar(current_user, size: :small), alt: current_user.name, class: "avatar-circle-mini" %>
-          <% end %>
-        <% else %>
-          <%= link_to t('devise.sessions.new.sign_in', default: 'ログイン'), new_user_session_path, class: 'btn btn-primary' %>
-          <%= link_to t('devise.registrations.new.sign_up', default: '新規登録'), new_user_registration_path, class: 'btn btn-success' %>
+
+    <!-- 右：アバター -->
+    <div class="d-flex align-items-center">
+      <% if user_signed_in? %>
+        <%= link_to user_path(current_user) do %>
+          <%= image_tag user_avatar(current_user, size: 36), class: "rounded-circle shadow-sm", style: "width: 36px; height: 36px; object-fit: cover;" %>
         <% end %>
-      </div>
+      <% else %>
+        <%= link_to 'ログイン', new_user_session_path, class: "btn btn-outline-dark btn-sm" %>
+      <% end %>
     </div>
 
   </div>

--- a/app/views/shared/_search_bar.html.erb
+++ b/app/views/shared/_search_bar.html.erb
@@ -4,10 +4,9 @@
 
   <%= hidden_field_tag :scope, scope %>
 
-  <div class="input-group shadow-sm bg-light rounded-2 overflow-hidden" style="max-width: 550px; width: 90%;">
-
-    <%= text_field_tag :q, params[:q], placeholder: placeholder || "検索", class: "form-control border-0 bg-light py-2" %>
-    <button type="submit" class="btn btn-primary border-0 px-3">
+  <div class="input-group search-box shadow-sm bg-white border rounded-pill overflow-hidden" style="max-width: 550px; width: 90%;">
+    <%= text_field_tag :q, params[:q], placeholder: placeholder || "検索", class: "form-control border-0 bg-white py-2" %>
+    <button type="submit" class="btn btn-primary border-0 px-4 rounded-pill">
       検索
     </button>
   </div>


### PR DESCRIPTION
💄 UI調整とデザイン統一のためのリファクタリング

 主な変更点
	•	ヘッダーをブック感あるデザインに刷新
	•	背景：rhodia-paper-header クラスで明るい書斎トーンに
	•	中央アイコンを虫眼鏡中心に配置するよう調整
	•	左：ロゴ、右：アバター、中央：ナビの3カラムバランス最適化
	•	検索・ソート・タグのフィルターUIを一体化
	•	アイコンを白枠＋シャドウ付きのラウンドボックスで囲い、視覚的なまとまりを強化
	•	アイコンサイズ・色味を調整し、操作感を上品に統一
	•	タグ一覧にも白背景ボックスを適用
	•	ソートUIと並列に見えるようにデザイン統一
	•	タグボタンにホバー時の浮き上がりアニメーションを追加
	•	フッターをヘッダーと統一した世界観に変更
	•	背景・フォント・余白・リンク色を調整
	•	画面下部に常に固定されるよう flex レイアウトを最適化
	•	ホバー時にテキストが本文と同じ色になるよう改善

その他
	•	モバイル対応は保持したまま、全体に「余白と静けさ」のあるUIに仕上げました
	•	今後もアイコンの配置バランスやレスポンシブ性の微調整がしやすくなっています