### PR TITLE
Introduce: RSpecとテスト環境を導入し、検索・書籍関連処理を調整

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require rails_helper

--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,10 @@ group :development, :test do
 
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false
+
+  gem "rspec-rails"
+
+  gem "factory_bot_rails"
 end
 
 group :development do
@@ -72,6 +76,7 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"
+  gem "shoulda-matchers", "~> 5.0"
 end
 
 gem "letter_opener", "~> 1.10"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,6 +143,7 @@ GEM
     devise-i18n (1.13.0)
       devise (>= 4.9.0)
       rails-i18n
+    diff-lcs (1.6.2)
     dockerfile-rails (1.7.9)
       rails (>= 3.0.0)
     dotenv (3.1.8)
@@ -154,6 +155,11 @@ GEM
     erubi (1.13.1)
     et-orbi (1.2.11)
       tzinfo
+    factory_bot (6.5.1)
+      activesupport (>= 6.1.0)
+    factory_bot_rails (6.4.4)
+      factory_bot (~> 6.5)
+      railties (>= 5.0.0)
     faraday (2.13.1)
       faraday-net_http (>= 2.0, < 3.5)
       json
@@ -391,6 +397,23 @@ GEM
       actionpack (>= 5.2)
       railties (>= 5.2)
     rexml (3.4.1)
+    rspec-core (3.13.3)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.4)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.4)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-rails (8.0.0)
+      actionpack (>= 7.2)
+      activesupport (>= 7.2)
+      railties (>= 7.2)
+      rspec-core (~> 3.13)
+      rspec-expectations (~> 3.13)
+      rspec-mocks (~> 3.13)
+      rspec-support (~> 3.13)
+    rspec-support (3.13.3)
     rubocop (1.75.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -447,6 +470,8 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    shoulda-matchers (5.3.0)
+      activesupport (>= 5.2.0)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -538,6 +563,7 @@ DEPENDENCIES
   devise-i18n
   dockerfile-rails (>= 1.7)
   dotenv-rails
+  factory_bot_rails
   image_processing (~> 1.2)
   importmap-rails
   jbuilder
@@ -557,8 +583,10 @@ DEPENDENCIES
   rakuten_web_service
   redcarpet (~> 3.6, >= 3.6.1)
   rexml
+  rspec-rails
   rubocop-rails-omakase
   selenium-webdriver
+  shoulda-matchers (~> 5.0)
   solid_cable
   solid_cache
   solid_queue

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,8 @@ class ApplicationController < ActionController::Base
     @guest_user ||= User.find_by(email: guest_email)
   end
 
+  TITLE_TRUNCATE_LIMIT = 40
+
   protected
 
   def configure_permitted_parameters

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -3,8 +3,6 @@ class BooksController < ApplicationController
   before_action :set_book, only: [ :show, :edit, :update, :destroy ]
   rescue_from ActiveRecord::RecordNotFound, with: :handle_record_not_found
 
-  TITLE_TRUNCATE_LIMIT = 40
-
   def index
     books = current_user.books
 
@@ -96,7 +94,7 @@ class BooksController < ApplicationController
         end
         format.html do
           flash[:info] = success_message
-          redirect_to books_path
+          redirect_to search_books_path
         end
       end
 

--- a/app/views/search/_google_results.html.erb
+++ b/app/views/search/_google_results.html.erb
@@ -25,7 +25,7 @@
 
           <!-- 本の情報 -->
           <div class="card-body d-flex flex-column px-3 py-2">
-            <p class="mb-1 small"><strong><%= book[:title]&.truncate(40) %></strong></p>
+            <p class="mb-1 small"><strong><%= book[:title]&.truncate(ApplicationController::TITLE_TRUNCATE_LIMIT) %></strong></p>
 
             <div class="mb-auto small text-muted">
               <p class="mb-1"><strong>著者:</strong> <%= book[:author] || '情報なし' %></p>

--- a/app/views/search/_isbn_result.html.erb
+++ b/app/views/search/_isbn_result.html.erb
@@ -20,7 +20,7 @@
 
     <!-- 情報 + フォーム -->
     <div class="flex-grow-1 text-md-center" style="max-width: 100%;">
-      <p class="mb-1 small"><strong><%= book[:title]&.truncate(40) %></strong></p>
+      <p class="mb-1 small"><strong><%= book[:title]&.truncate(ApplicationController::TITLE_TRUNCATE_LIMIT) %></strong></p>
       <p class="mb-1 small"><strong>著者:</strong> <%= book[:author] || "情報なし" %></p>
       <p class="mb-1 small"><strong>出版社:</strong> <%= book[:publisher] || "情報なし" %></p>
 

--- a/app/views/search/_rakuten_results.html.erb
+++ b/app/views/search/_rakuten_results.html.erb
@@ -19,7 +19,7 @@
 
             <!-- 情報 -->
             <div class="card-body d-flex flex-column px-3 py-2">
-              <p class="mb-1 small"><strong><%= book.title.truncate(40) %></strong></p>
+              <p class="mb-1 small"><strong><%= book.title.truncate(ApplicationController::TITLE_TRUNCATE_LIMIT) %></strong></p>
 
               <div class="mb-auto small text-muted">
                 <p class="mb-1"><strong>著者:</strong> <%= book.author || '情報なし' %></p>

--- a/spec/factories/book.rb
+++ b/spec/factories/book.rb
@@ -1,0 +1,13 @@
+# spec/factories/books.rb
+FactoryBot.define do
+  factory :book do
+    title { "サンプルタイトル" }
+    sequence(:isbn) { |n| "9781234567#{format('%03d', n)}" }
+    publisher { "出版社名" }
+    page { 300 }
+    author { "著者名" }
+    price { 1500 }
+    status { :want_to_read }
+    association :user
+  end
+end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,0 +1,9 @@
+# spec/factories/users.rb
+FactoryBot.define do
+  factory :user do
+    sequence(:email) { |n| "user#{n}@example.com" }
+    password { "password123" }
+    password_confirmation { "password123" }
+    confirmed_at { Time.current }
+  end
+end

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -1,0 +1,92 @@
+require 'rails_helper'
+
+RSpec.describe Book, type: :model do
+  describe "ファクトリ" do
+    it "有効なファクトリを持つ" do
+      expect(build(:book)).to be_valid
+    end
+  end
+
+  describe "バリデーション" do
+    it "ISBNが重複する場合は無効（同じユーザー内）" do
+      user = create(:user)
+      create(:book, user: user, isbn: "9781234567890")
+      duplicate = build(:book, user: user, isbn: "9781234567890")
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:isbn]).to include(": この書籍はMy本棚に登録済みです")
+    end
+
+    it "ISBNが空文字列なら保存される（normalize_isbn）" do
+      book = build(:book, isbn: "")
+      book.validate
+      expect(book.isbn).to be_nil
+      expect(book).to be_valid
+    end
+
+    it "別のユーザーなら同じISBNを登録できる" do
+      isbn = "9781234567890"
+      create(:book, user: create(:user), isbn: isbn)
+      another = build(:book, user: create(:user), isbn: isbn)
+      expect(another).to be_valid
+    end
+  end
+
+  describe "アソシエーション" do
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to have_many(:memos).dependent(:destroy) }
+    it { is_expected.to have_many(:images).dependent(:destroy) }
+
+    it "book_cover_s3 がアタッチ可能であること" do
+      expect(Book.new).to respond_to(:book_cover_s3)
+    end
+  end
+
+  describe "タグ機能" do
+    it "タグを付けられる" do
+      user = create(:user)
+      book = create(:book, user: user)
+
+      ActsAsTaggableOn::Tag.class_eval do
+        before_validation do
+          self.user_id ||= user.id
+        end
+      end
+
+      book.tag_list.add("哲学", "小説")
+      book.save!
+      expect(book.reload.tag_list).to include("哲学", "小説")
+    end
+  end
+
+  describe "ステータス (enum)" do
+    it "初期状態は want_to_read" do
+      book = build(:book)
+      expect(book.status).to eq("want_to_read")
+    end
+
+    it "reading や finished に変更できる" do
+      book = build(:book, status: :reading)
+      expect(book.status).to eq("reading")
+
+      book.status = :finished
+      expect(book.status).to eq("finished")
+    end
+  end
+
+  describe "pg_search_scope :search_by_title_and_author" do
+    let(:user) { create(:user) }
+    let!(:book1) { create(:book, title: "星の王子さま", author: "サン＝テグジュペリ", isbn: "9781111111111", user: user) }
+    let!(:book2) { create(:book, title: "アルケミスト", author: "パウロ・コエーリョ", isbn: "9782222222222", user: user) }
+    it "タイトルで検索できる" do
+      results = Book.search_by_title_and_author("星の王子")
+      expect(results).to include(book1)
+      expect(results).not_to include(book2)
+    end
+
+    it "著者名で検索できる" do
+      results = Book.search_by_title_and_author("パウロ")
+      expect(results).to include(book2)
+      expect(results).not_to include(book1)
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,18 @@
+# spec/models/user_spec.rb
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  it "有効なファクトリを持つ" do
+    expect(build(:user)).to be_valid
+  end
+
+  it "メールが必須であること" do
+    user = build(:user, email: nil)
+    expect(user).not_to be_valid
+  end
+
+  it "パスワードが必須であること" do
+    user = build(:user, password: nil)
+    expect(user).not_to be_valid
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,0 +1,34 @@
+# This file is copied to spec/ when you run 'rails generate rspec:install'
+require 'spec_helper'
+ENV['RAILS_ENV'] ||= 'test'
+require_relative '../config/environment'
+
+abort("The Rails environment is running in production mode!") if Rails.env.production?
+
+require 'rspec/rails'
+
+begin
+  ActiveRecord::Migration.maintain_test_schema!
+rescue ActiveRecord::PendingMigrationError => e
+  abort e.to_s.strip
+end
+RSpec.configure do |config|
+  config.fixture_paths = [
+    Rails.root.join('spec/fixtures')
+  ]
+
+  config.use_transactional_fixtures = true
+
+  config.filter_rails_from_backtrace!
+
+  config.include FactoryBot::Syntax::Methods
+
+  config.include Devise::Test::IntegrationHelpers, type: :request
+end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end

--- a/spec/requests/books_spec.rb
+++ b/spec/requests/books_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+RSpec.describe "Books", type: :request do
+  let(:user) { create(:user, password: "password123", confirmed_at: Time.current) }
+
+  before do
+    post user_session_path, params: {
+      user: {
+        email: user.email,
+        password: "password123"
+      }
+    }
+  end
+
+  describe "GET /books/:id" do
+    it "書籍の詳細が表示される" do
+      book = create(:book, user: user, title: "詳細テスト本")
+
+      get book_path(book)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("詳細テスト本")
+    end
+  end
+
+  describe "POST /books" do
+    it "書籍を新規登録し、search_books_pathにリダイレクト & フラッシュ表示" do
+      long_title = "これは非常に長いタイトルで、40文字以上のものを用意しておきますね。Application_controllerで40を代入しています"
+      post books_path, params: {
+        book: {
+          title: long_title,
+          isbn: "9781234567890"
+        }
+      }
+
+      expect(response).to redirect_to(search_books_path)
+      follow_redirect!
+
+      truncated_title = long_title.truncate(ApplicationController::TITLE_TRUNCATE_LIMIT)
+      expect(response.body).to include("My本棚に『#{truncated_title}』を追加しました")
+    end
+  end
+
+  describe "PATCH /books/:id" do
+    it "書籍の情報を更新できる & フラッシュ表示" do
+      book = create(:book, user: user, title: "古いタイトル")
+      long_title = "新しいタイトルに関する考察を繰り返し述べることで理解を深める試み"
+
+      patch book_path(book), params: {
+        book: {
+          title: long_title
+        }
+      }
+
+      expect(response).to redirect_to(book_path(book))
+      follow_redirect!
+      expect(response.body).to include("新しいタイトル")
+      truncated_title = long_title.truncate(ApplicationController::TITLE_TRUNCATE_LIMIT)
+      expect(response.body).to include("『#{truncated_title}』を更新しました")
+    end
+  end
+
+  describe "DELETE /books/:id" do
+    it "書籍を削除できる（タイトル確認あり）" do
+      create(:book, user: user, title: "残す本")
+      long_title = "削除対象の本に関する長めのタイトル（繰り返し確認用）"
+      book = create(:book, user: user, title: long_title)
+
+      expect {
+        delete book_path(book)
+      }.to change(Book, :count).by(-1)
+
+      expect(response).to redirect_to(books_path)
+      follow_redirect!
+
+      truncated_title = long_title.truncate(ApplicationController::TITLE_TRUNCATE_LIMIT)
+      expect(response.body).to include("『#{truncated_title}』を削除しました")
+      expect(response.body).to include("残す本")
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,9 @@
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+end


### PR DESCRIPTION
## 概要

- RSpecを導入し、テスト環境を構築しました。
- 書籍に関するリクエストスペック（GET/POST/PATCH/DELETE）を追加。
- 検索結果のビュー（Rakuten/Google/ISBN）を整理し、表示に一貫性を持たせました。

## 主な変更点

- `.rspec`, `spec_helper.rb`, `rails_helper.rb` の追加
- - `Book`モデルのspecを作成し、バリデーション、アソシエーション、enum、タグ機能、全文検索（pg_search）などの基本動作を網羅
- TITLE_TRUNCATE_LIMITをApplicationControllerに定義
- `Book::TITLE_TRUNCATE_LIMIT` の挙動に関しても、テストで再現できるよう定数扱いで整備。

## 今後の対応予定
- `User`モデルや他の関連モデル（Memo, Tagなど）のモデルスペックも順次追加予定
- search_books や memo 関連のテストも今後追加予定
- request spec と feature spec の役割整理