### PR TITLE
Feature/bookshelf infinite

### DIFF
--- a/app/controllers/guest/books_controller.rb
+++ b/app/controllers/guest/books_controller.rb
@@ -1,6 +1,6 @@
 module Guest
   class BooksController < ApplicationController
-    CHUNKS_PER_PAGE = 7
+    CHUNKS_PER_PAGE = 14
     def show
       @book = guest_user.books.find(params[:id])
 
@@ -49,18 +49,6 @@ module Guest
 
       books_per_page = unit_per_page * CHUNKS_PER_PAGE
       @pagy, @books = pagy(books, limit: books_per_page)
-
-      if @view_mode == "shelf"
-        if turbo_frame_request?
-          render partial: "bookshelf/kino_chunk", locals: {
-            books: @books,
-            books_per_shelf: @books_per_shelf,
-            pagy: @pagy
-          }, layout: false
-        else
-          render :index
-        end
-      end
     end
   end
 end

--- a/app/views/bookshelf/_kino_chunk.html.erb
+++ b/app/views/bookshelf/_kino_chunk.html.erb
@@ -1,3 +1,8 @@
 <turbo-frame id="next_books">
   <%= render "bookshelf/kino_books_grid", books: books, books_per_shelf: books_per_shelf, pagy: pagy %>
 </turbo-frame>
+
+<!-- タグ・フィルター用 -->
+<turbo-frame id="books_frame">
+  <%= render partial: "bookshelf/kino_books_grid", locals: { books: books, books_per_shelf: books_per_shelf, pagy: pagy } %>
+</turbo-frame>

--- a/app/views/guest/books/index.html.erb
+++ b/app/views/guest/books/index.html.erb
@@ -44,18 +44,16 @@
   <div class="flex-shrink-0 d-none-sm" style="width: 48px;"></div> <!-- サイズ合わせ用 -->
 </div>
 
-<turbo-frame id="books_frame">
   <% if @view_mode == "shelf" %>
-    <%= render "bookshelf/kino_select_numbers", books_per_shelf: @books_per_shelf %>
-    <%= render "bookshelf/kino_books_grid",
+    <%= render "guest/bookshelf/kino_select_numbers", books_per_shelf: @books_per_shelf %>
+    <%= render "guest/bookshelf/kino_chunk",
             books: @books,
             books_per_shelf: @books_per_shelf,
             pagy: @pagy,
             current_chunk_index: @pagy.page %>
   <% else %>
-    <%= render "bookshelf/simple_card", books: @books, card_columns: @card_columns %>
+    <%= render "guest/bookshelf/simple_card", books: @books, card_columns: @card_columns, pagy: @pagy %>
   <% end %>
-</turbo-frame>
 
 
 

--- a/app/views/guest/bookshelf/_kino_books_grid.html.erb
+++ b/app/views/guest/bookshelf/_kino_books_grid.html.erb
@@ -1,0 +1,34 @@
+<% books.each_slice(books_per_shelf) do |row_books| %>
+  <div class="shelf-row" data-controller="book-shelf">
+    <div class="book-row">
+      <% row_books.each do |book| %>
+        <div class="book-on-shelf">
+          <%= link_to book_link_path(book), data: { turbo_frame: "_top" } do %>
+            <% if book.book_cover_s3.attached? %>
+              <%= image_tag book.book_cover_s3.variant(resize_to_limit: [200, 200]),
+                    alt: book.title, class: "book-cover", loading: "lazy" %>
+            <% elsif book.book_cover.present? %>
+              <img src="<%= book.book_cover %>" alt="表紙画像" class="book-cover" loading="lazy">
+            <% else %>
+              <div class="no-cover">
+                <span class="title">
+                  <%= book.title.truncate(24, omission: "").ljust(10).gsub(" ", "&nbsp;").html_safe %>
+                </span>
+              </div>
+            <% end %>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+    <div class="shelf-bar"></div>
+    <div class="shelf-depth"></div>
+  </div>
+<% end %>
+
+<% if current_user && pagy && pagy.next %>
+  <turbo-frame id="next_books" src="<%= books_path(view: @view_mode, page: pagy.next) %>" loading="lazy">
+    <div class="text-center my-4">
+      <div class="spinner-border text-secondary" role="status"></div>
+    </div>
+  </turbo-frame>
+<% end %>

--- a/app/views/guest/bookshelf/_kino_chunk.html.erb
+++ b/app/views/guest/bookshelf/_kino_chunk.html.erb
@@ -1,0 +1,3 @@
+<turbo-frame id="next_books">
+  <%= render "guest/bookshelf/kino_books_grid", books: books, books_per_shelf: books_per_shelf, pagy: pagy %>
+</turbo-frame>

--- a/app/views/guest/bookshelf/_kino_select_numbers.html.erb
+++ b/app/views/guest/bookshelf/_kino_select_numbers.html.erb
@@ -1,0 +1,17 @@
+<%= form_with url: books_index_path, method: :get,
+              data: { controller: "auto-submit", turbo: false },
+              local: true,
+              class: "ms-3" do %>
+
+  <%= hidden_field_tag :view, "shelf" %>
+
+  <% options = mobile? ? [5, 10] : [5, 7, 10, 12] %>
+
+  <%= select_tag :per,
+      options_for_select(options, books_per_shelf),
+      class: "form-select form-select-sm text-secondary shadow-sm books-per-shelf",
+      data: {
+        auto_submit_target: "select",
+        action: "change->auto-submit#change"
+      } %>
+<% end %>

--- a/app/views/guest/bookshelf/_simple_card.html.erb
+++ b/app/views/guest/bookshelf/_simple_card.html.erb
@@ -35,8 +35,3 @@
   <%= hidden_field_tag :view, "card" %>
   <%= hidden_field_tag :column, card_columns, id: "hiddenColumnInput" %>
 <% end %>
-
-
-<div class="my-5 d-flex justify-content-center">
-  <%== pagy_bootstrap_nav(@pagy) %>
-</div>


### PR DESCRIPTION
ゲスト向けの本棚ビューでTurbo Frame＋Stimulusによる自動遅延読み込みを試みていましたが、
Turboの履歴管理やframe遷移の影響で、意図せず通常の`books#index`にアクセスしてしまうケースが発生していました。

このPRでは、該当ビューをあえてシンプルな構成に戻し、
ゲストユーザーにも確実で安定した表示を提供できるよう修正しています。