### PR TITLE
Feature/bookshelf detail view

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -43,6 +43,6 @@ class ApplicationController < ActionController::Base
   end
 
   def default_detail_card_columns
-    mobile? ? 1 : 3
+    mobile? ? 1 : 6
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -41,4 +41,8 @@ class ApplicationController < ActionController::Base
   def default_card_columns
     mobile? ? 4 : 12
   end
+
+  def default_detail_card_columns
+    mobile? ? 1 : 3
+  end
 end

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -16,12 +16,14 @@ class BooksController < ApplicationController
 
     display = BooksDisplaySetting.new(session, params, {
       shelf: default_books_per_shelf,
-      card: default_card_columns
-    })
+      card: default_card_columns,
+      detail_card: default_detail_card_columns
+    }, mobile: mobile?)
 
     @view_mode = display.view_mode
     @books_per_shelf = display.books_per_shelf
     @card_columns = display.card_columns
+    @detail_card_columns = display.detail_card_columns
 
     books = BooksQuery.new(books, params: params, current_user: current_user).call
 

--- a/app/controllers/guest/books_controller.rb
+++ b/app/controllers/guest/books_controller.rb
@@ -3,7 +3,7 @@ module Guest
     before_action :read_only
     before_action :set_guest_book, only: [ :show ]
     rescue_from ActiveRecord::RecordNotFound, with: :handle_guest_not_found
-    CHUNKS_PER_PAGE = 14
+    CHUNKS_PER_PAGE = 10
     def index
       books = guest_user.books
                   .includes(book_cover_s3_attachment: :blob)
@@ -15,12 +15,14 @@ module Guest
 
       display = BooksDisplaySetting.new(session, params, {
         shelf: default_books_per_shelf,
-        card: default_card_columns
-      })
+        card: default_card_columns,
+        detail_card: default_detail_card_columns
+        }, mobile: mobile?)
 
       @view_mode       = display.view_mode
       @books_per_shelf = display.books_per_shelf
       @card_columns    = display.card_columns
+      @detail_card_columns = display.detail_card_columns
 
       books_per_page = display.unit_per_page * CHUNKS_PER_PAGE
       @pagy, @books = pagy(books, limit: books_per_page)

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -13,6 +13,7 @@ import AutoRemoveController from "./controllers/auto_remove_controller.js"
 import AutoSubmitController from "./controllers/auto_submit_controller.js"
 import InfiniteScrollController from "./controllers/infinite_scroll_controller.js"
 import SafariClickFixController from "./controllers/safari_click_fix_controller.js"
+import DetailCardColumnSelectorController from "./controllers/detail_card_column_selector_controller.js"
 
 const application = Application.start()
 window.Stimulus = application
@@ -31,6 +32,7 @@ application.register("auto-remove", AutoRemoveController)
 application.register("auto-submit", AutoSubmitController)
 application.register("infinite-scroll", InfiniteScrollController)
 application.register("safari-click-fix", SafariClickFixController)
+application.register("detail-card-column-selector", DetailCardColumnSelectorController)
 
 import * as bootstrap from "bootstrap"
 window.bootstrap = bootstrap  // グローバルにしたい場合

--- a/app/javascript/controllers/detail_card_column_selector_controller.js
+++ b/app/javascript/controllers/detail_card_column_selector_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["selector"]
+
+  change(event) {
+    const cols = event.target.value
+
+    const hiddenInput = document.getElementById("hiddenColumnInput")
+    if (hiddenInput) {
+      hiddenInput.value = cols
+    }
+
+    const form = document.getElementById("columnForm")
+    if (form) {
+      form.requestSubmit()
+    }
+  }
+}

--- a/app/services/books_display_setting.rb
+++ b/app/services/books_display_setting.rb
@@ -1,16 +1,19 @@
 # frozen_string_literal: true
 
 class BooksDisplaySetting
-  VIEW_MODE_KEY      = :view_mode
-  SHELF_PER_KEY      = :shelf_per
-  CARD_COLUMNS_KEY   = :card_columns
+  VIEW_MODE_KEY           = :view_mode
+  SHELF_PER_KEY           = :shelf_per
+  CARD_COLUMNS_KEY        = :card_columns
+  DETAIL_CARD_COLUMNS_KEY = :detail_card_columns
 
-  attr_reader :view_mode, :unit_per_page, :books_per_shelf, :card_columns
+  attr_reader :view_mode, :unit_per_page,
+              :books_per_shelf, :card_columns, :detail_card_columns
 
-  def initialize(session, params, defaults)
+  def initialize(session, params, defaults, mobile: false)
     @session = session
     @params = params
     @defaults = defaults
+    @mobile = mobile
 
     configure_view_mode
     configure_unit_per_page
@@ -33,6 +36,10 @@ class BooksDisplaySetting
       @session[CARD_COLUMNS_KEY] = @params[:column] if @params[:column].present?
       @card_columns = @session[CARD_COLUMNS_KEY]&.to_i || @defaults[:card]
       @unit_per_page = @card_columns
+    when "detail_card"
+      @session[DETAIL_CARD_COLUMNS_KEY] = @params[:column] if @params[:column].present?
+      @detail_card_columns = @session[DETAIL_CARD_COLUMNS_KEY]&.to_i || @defaults[:detail_card]
+      @unit_per_page = @mobile ? @detail_card_columns * 4 : @detail_card_columns
     else
       @unit_per_page = @defaults[:shelf]
     end

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -5,19 +5,23 @@
 <div class="d-flex align-items-center justify-content-between mt-4 mb-3 px-3">
 
   <!-- ⬅ 左端：ビュー切り替え -->
-  <div class="flex-shrink-0">
-    <%= link_to (books_path(view: @view_mode == "shelf" ? "card" : "shelf")),
-                class: "btn btn-light border shadow-sm d-flex align-items-center justify-content-center",
-                style: "width: 40px; height: 40px; border-radius: 50%; line-height: 1;",
-                title: (@view_mode == "shelf" ? "カードビューに切り替え" : "棚ビューに切り替え") do %>
-      <% if @view_mode == "shelf" %>
-        <i class="bi bi-card-text fs-5 icon-refined"></i>
-      <% else %>
-        <i class="bi bi-layout-three-columns fs-5 icon-refined"></i>
-      <% end %>
-    <% end %>
-  </div>
+<% next_view, icon_class, title_text = case @view_mode
+  when "shelf"
+    ["card", "bi-card-text", "カードビューに切り替え"]
+  when "card"
+    ["detail_card", "bi-layout-text-sidebar", "詳細カードビューに切り替え"]
+  else
+    ["shelf", "bi-layout-three-columns", "棚ビューに切り替え"]
+  end %>
 
+<div class="flex-shrink-0">
+  <%= link_to books_path(view: next_view),
+              class: "btn btn-light border shadow-sm d-flex align-items-center justify-content-center",
+              style: "width: 40px; height: 40px; border-radius: 50%; line-height: 1;",
+              title: title_text do %>
+    <i class="bi <%= icon_class %> fs-5 icon-refined"></i>
+  <% end %>
+</div>
   <!--  中央：４つのボタンのコントロールバー -->
   <%= render "books/filter_controlls", filtered_tag: @filtered_tag, filtered_tags: @filtered_tags, filtered_status: @filtered_status %>
 
@@ -28,4 +32,3 @@
               pagy: @pagy,
               view_mode: @view_mode,
               card_columns: @card_columns %>
-

--- a/app/views/bookshelf/_books_frame_wrapper.html.erb
+++ b/app/views/bookshelf/_books_frame_wrapper.html.erb
@@ -6,7 +6,13 @@
             books_per_shelf: books_per_shelf,
             pagy: pagy,
             current_chunk_index: pagy.page %>
-  <% else %>
+  <% end %>
+
+  <% if view_mode == "card" %>
     <%= render "bookshelf/simple_card", books: books, card_columns: card_columns, pagy: pagy %>
+  <% end %>
+
+  <% if view_mode == "detail_card" %>
+    <%= render "bookshelf/detail_card", books: books, pagy: pagy, detail_card_columns: @detail_card_columns %>
   <% end %>
 </turbo-frame>

--- a/app/views/bookshelf/_detail_card.html.erb
+++ b/app/views/bookshelf/_detail_card.html.erb
@@ -1,0 +1,72 @@
+<div data-controller="detail-card-column-selector">
+  <% default_value = mobile? ? 1 : 6 %>
+  <% options = mobile? ? [1, 2, 3] : [4, 6, 12] %>
+
+  <div class="d-flex align-items-center mb-4 ms-3" style="gap: 0.5rem;">
+    <%= select_tag :column,
+        options_for_select(options, detail_card_columns || default_value),
+        id: "columnSelect",
+        data: {
+          action: "change->detail-card-column-selector#change",
+          detail_card_column_selector_target: "selector"
+        },
+        class: "form-select form-select-sm text-secondary shadow-sm books-per-shelf"
+    %>
+  </div>
+
+  <%= form_with url: books_index_path, method: :get, local: true, id: "columnForm" do %>
+    <%= hidden_field_tag :view, "detail_card" %>
+    <%= hidden_field_tag :column, detail_card_columns, id: "hiddenColumnInput" %>
+  <% end %>
+</div>
+
+<% col_width = case @detail_card_columns.to_i
+  when 1 then 12
+  when 2 then 6
+  when 3 then 4
+  when 4 then 3
+  when 6 then 2
+  when 12 then 1
+  else 3
+end %>
+
+<div class="row g-3 px-3 mt-3">
+  <% books.each do |book| %>
+    <div class="col-<%= col_width %>">
+      <%= link_to book_link_path(book), class: "text-decoration-none text-reset" do %>
+        <div class="card h-100 shadow-sm p-3 bg-light-bok">
+          <div class="row g-3">
+            <!-- 書影 -->
+            <div class="col-auto">
+              <% if book.book_cover_s3.attached? %>
+                <%= image_tag book.book_cover_s3.variant(resize_to_fill: [100, 150]),
+                      alt: book.title, class: "book-cover", loading: "lazy" %>
+              <% elsif book.book_cover.present? %>
+                <%= image_tag book.book_cover,
+                      class: "img-fluid rounded-2",
+                      style: "width: 100px; height: auto; object-fit: cover;" %>
+              <% else %>
+                <div class="no-cover text-muted rounded-2"
+                      style="width: 100px;">
+                  <span class="small text-center title px-1"><%= book.title %></span>
+                </div>
+              <% end %>
+            </div>
+            <!-- 右側テキスト情報 -->
+            <div class="col d-flex flex-column gap-1" style="word-break: break-all;">
+              <h6 class="mb-1 fw-bold lh-sm"><%= truncate(book.title, length: 40) %></h6>
+              <p class="text-muted mb-1 small lh-sm"><%= truncate(book.author, length: 30) %></p>
+              <p class="text-muted small lh-sm mb-2"><%= truncate(book.publisher, length: 30) %></p>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+</div>
+
+<% if pagy %>
+  <div class="my-5 d-flex justify-content-center">
+    <%== pagy_bootstrap_nav(pagy) %>
+  </div>
+<% end %>

--- a/app/views/bookshelf/_simple_card.html.erb
+++ b/app/views/bookshelf/_simple_card.html.erb
@@ -38,7 +38,7 @@
 
 
 
-<% if pagy && pagy.next %>
+<% if pagy %>
   <div class="my-5 d-flex justify-content-center">
     <%== pagy_bootstrap_nav(pagy) %>
   </div>

--- a/app/views/guest/books/index.html.erb
+++ b/app/views/guest/books/index.html.erb
@@ -5,17 +5,21 @@
 
 <div class="d-flex align-items-center justify-content-between mt-4 mb-3 px-3">
 
-  <!-- ⬅ 左端：ビュー切り替え -->
+  <% next_view, icon_class, title_text = case @view_mode
+    when "shelf"
+      ["card", "bi-card-text", "カードビューに切り替え"]
+    when "card"
+      ["detail_card", "bi-layout-text-sidebar", "詳細カードビューに切り替え"]
+    else
+      ["shelf", "bi-layout-three-columns", "棚ビューに切り替え"]
+    end %>
+
   <div class="flex-shrink-0">
-    <%= link_to guest_books_path(view: @view_mode == "shelf" ? "card" : "shelf"),
+    <%= link_to guest_books_path(view: next_view),
                 class: "btn btn-light border shadow-sm d-flex align-items-center justify-content-center",
                 style: "width: 40px; height: 40px; border-radius: 50%; line-height: 1;",
-                title: (@view_mode == "shelf" ? "カードビューに切り替え" : "棚ビューに切り替え") do %>
-      <% if @view_mode == "shelf" %>
-        <i class="bi bi-card-text fs-5 icon-refined"></i>
-      <% else %>
-        <i class="bi bi-layout-three-columns fs-5 icon-refined"></i>
-      <% end %>
+                title: title_text do %>
+      <i class="bi <%= icon_class %> fs-5 icon-refined"></i>
     <% end %>
   </div>
     <div class="mx-auto">
@@ -47,16 +51,19 @@
   <div class="flex-shrink-0 d-none-sm" style="width: 48px;"></div> <!-- サイズ合わせ用 -->
 </div>
 
-  <% if @view_mode == "shelf" %>
-    <%= render "guest/bookshelf/kino_select_numbers", books_per_shelf: @books_per_shelf %>
-    <%= render "guest/bookshelf/kino_chunk",
-            books: @books,
-            books_per_shelf: @books_per_shelf,
-            pagy: @pagy,
-            current_chunk_index: @pagy.page %>
-  <% else %>
-    <%= render "guest/bookshelf/simple_card", books: @books, card_columns: @card_columns, pagy: @pagy %>
-  <% end %>
+<% if @view_mode == "shelf" %>
+  <%= render "guest/bookshelf/kino_select_numbers", books_per_shelf: @books_per_shelf %>
+  <%= render "guest/bookshelf/kino_chunk",
+          books: @books,
+          books_per_shelf: @books_per_shelf,
+          pagy: @pagy,
+          current_chunk_index: @pagy.page %>
+<% end %>
 
+<% if @view_mode == "card" %>
+  <%= render "guest/bookshelf/simple_card", books: @books, card_columns: @card_columns, pagy: @pagy %>
+<% end %>
 
-
+<% if @view_mode == "detail_card" %>
+  <%= render "guest/bookshelf/detail_card", books: @books, detail_card_columns: @detail_card_columns, pagy: @pagy %>
+<% end %>

--- a/app/views/guest/bookshelf/_detail_card.html.erb
+++ b/app/views/guest/bookshelf/_detail_card.html.erb
@@ -1,0 +1,72 @@
+<div data-controller="detail-card-column-selector">
+  <% default_value = mobile? ? 1 : 6 %>
+  <% options = mobile? ? [1, 2, 3] : [4, 6, 12] %>
+
+  <div class="d-flex align-items-center mb-4 ms-3" style="gap: 0.5rem;">
+    <%= select_tag :column,
+        options_for_select(options, detail_card_columns || default_value),
+        id: "columnSelect",
+        data: {
+          action: "change->detail-card-column-selector#change",
+          detail_card_column_selector_target: "selector"
+        },
+        class: "form-select form-select-sm text-secondary shadow-sm books-per-shelf"
+    %>
+  </div>
+
+  <%= form_with url: books_index_path, method: :get, local: true, id: "columnForm" do %>
+    <%= hidden_field_tag :view, "detail_card" %>
+    <%= hidden_field_tag :column, detail_card_columns, id: "hiddenColumnInput" %>
+  <% end %>
+</div>
+
+<% col_width = case @detail_card_columns.to_i
+  when 1 then 12
+  when 2 then 6
+  when 3 then 4
+  when 4 then 3
+  when 6 then 2
+  when 12 then 1
+  else 3
+end %>
+
+<div class="row g-3 px-3 mt-3">
+  <% books.each do |book| %>
+    <div class="col-<%= col_width %>">
+      <%= link_to book_link_path(book), class: "text-decoration-none text-reset" do %>
+        <div class="card h-100 shadow-sm p-3 bg-light-bok">
+          <div class="row g-3">
+            <!-- 書影 -->
+            <div class="col-auto">
+              <% if book.book_cover_s3.attached? %>
+                <%= image_tag book.book_cover_s3.variant(resize_to_fill: [100, 150]),
+                      alt: book.title, class: "book-cover", loading: "lazy" %>
+              <% elsif book.book_cover.present? %>
+                <%= image_tag book.book_cover,
+                      class: "img-fluid rounded-2",
+                      style: "width: 100px; height: auto; object-fit: cover;" %>
+              <% else %>
+                <div class="no-cover text-muted rounded-2"
+                      style="width: 100px;">
+                  <span class="small text-center title px-1"><%= book.title %></span>
+                </div>
+              <% end %>
+            </div>
+            <!-- 右側テキスト情報 -->
+            <div class="col d-flex flex-column gap-1" style="word-break: break-all;">
+              <h6 class="mb-1 fw-bold lh-sm"><%= truncate(book.title, length: 40) %></h6>
+              <p class="text-muted mb-1 small lh-sm"><%= truncate(book.author, length: 30) %></p>
+              <p class="text-muted small lh-sm mb-2"><%= truncate(book.publisher, length: 30) %></p>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+</div>
+
+<% if current_user && pagy && pagy.next %>
+  <div class="my-5 d-flex justify-content-center">
+    <%== pagy_bootstrap_nav(pagy) %>
+  </div>
+<% end %>

--- a/app/views/public_bookshelf/_public_card.html.erb
+++ b/app/views/public_bookshelf/_public_card.html.erb
@@ -4,10 +4,15 @@
       <div class="row g-3">
         <!-- 書影 -->
         <div class="col-auto">
-          <% if memo.book.book_cover.present? %>
+          <% if memo.book.book_cover_s3.attached? %>
+            <%= image_tag memo.book.book_cover_s3.variant(resize_to_fit: [100, 150]),
+                  alt: memo.book.title, class: "book-cover", loading: "lazy" %>
+
+          <% elsif memo.book.book_cover.present? %>
             <%= image_tag memo.book.book_cover,
                   class: "img-fluid rounded-2",
                   style: "width: 100px; height: auto; object-fit: cover;" %>
+
           <% else %>
             <div class="no-cover text-muted rounded-2"
                   style="width: 100px; height: 150px;">

--- a/spec/requests/books_controller_spec.rb
+++ b/spec/requests/books_controller_spec.rb
@@ -33,9 +33,10 @@ RSpec.describe "BooksController", type: :request do
       before { sign_in user }
 
       it "サンプル本棚ページが表示されること" do
-        get books_path
+        get guest_books_path
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("サンプル本棚")
+        expect(response.body).to include("こちらはサンプル表示です")
         expect(response.body).to include("スターター本")
       end
     end


### PR DESCRIPTION
### 概要

本棚ビューに新たに detail_card view を追加しました。
表示カラム数の切り替えが可能で、スマホでは自動的に行数を調整します。
ゲストモードでも利用できます。

### 主な対応
- detail_card ビューの新設（レイアウト・内容情報あり）
- 列数のセレクトボックス + Stimulus による切り替え機能
- BooksDisplaySetting でセッション管理を統一
- ゲスト用にも対応（ビュー/コントローラ）
