### PR TITLE
Feature/bookshelf spine view

### DIFF
--- a/app/assets/builds/application.js
+++ b/app/assets/builds/application.js
@@ -76530,6 +76530,64 @@ img.ProseMirror-separator {
   __publicField(book_edit_controller_default, "targets", ["title", "author", "publisher"]);
   __publicField(book_edit_controller_default, "values", { id: Number, index: Number });
 
+  // app/javascript/controllers/spine_book_controller.js
+  var spine_book_controller_default = class extends Controller {
+    connect() {
+      this.expanded = false;
+      this.handleDocumentClick = this.handleDocumentClick.bind(this);
+      this.handleEscape = this.handleEscape.bind(this);
+    }
+    handleClick(event) {
+      if (!this.expanded) {
+        this.expand();
+      } else {
+        window.location.href = this.linkUrlValue;
+      }
+    }
+    expand() {
+      this.expanded = true;
+      this.element.classList.add("expanded");
+      if (this.hasCoverTarget) {
+        this.element.classList.add("with-cover");
+        this.coverTarget.classList.remove("d-none");
+        this.titleTarget.classList.add("d-none");
+      } else {
+        this.titleTarget.classList.add("expanded-title");
+      }
+      document.addEventListener("click", this.handleDocumentClick);
+      document.addEventListener("keydown", this.handleEscape);
+    }
+    collapse() {
+      this.expanded = false;
+      this.element.classList.remove("expanded", "with-cover");
+      this.element.classList.remove("expanded");
+      if (this.hasCoverTarget) {
+        this.coverTarget.classList.add("d-none");
+        this.titleTarget.classList.remove("d-none");
+      } else {
+        this.titleTarget.classList.remove("expanded-title");
+      }
+      document.removeEventListener("click", this.handleDocumentClick);
+      document.removeEventListener("keydown", this.handleEscape);
+    }
+    handleDocumentClick(event) {
+      if (!this.element.contains(event.target)) {
+        this.collapse();
+      }
+    }
+    handleEscape(event) {
+      if (event.key === "Escape") {
+        this.collapse();
+      }
+    }
+    disconnect() {
+      document.removeEventListener("click", this.handleDocumentClick);
+      document.removeEventListener("keydown", this.handleEscape);
+    }
+  };
+  __publicField(spine_book_controller_default, "targets", ["title", "cover"]);
+  __publicField(spine_book_controller_default, "values", { linkUrl: String });
+
   // node_modules/bootstrap/dist/js/bootstrap.esm.js
   var bootstrap_esm_exports = {};
   __export(bootstrap_esm_exports, {
@@ -102723,6 +102781,7 @@ img.ProseMirror-separator {
   application.register("safari-click-fix", safari_click_fix_controller_default);
   application.register("detail-card-column-selector", detail_card_column_selector_controller_default);
   application.register("book-edit", book_edit_controller_default);
+  application.register("spine-book", spine_book_controller_default);
   window.bootstrap = bootstrap_esm_exports;
   window.Turbo = turbo_es2017_esm_exports;
   document.addEventListener("turbo:load", () => {

--- a/app/assets/stylesheets/_buttons.scss
+++ b/app/assets/stylesheets/_buttons.scss
@@ -5,6 +5,7 @@
   border-radius: 999px;
   background-color: #f9f9f9;
 }
+
 .btn-primary-bok {
   --bs-btn-color: #fff;
   --bs-btn-bg: #2d61d1;
@@ -26,4 +27,11 @@
 .safari-modal-action-button {
   -webkit-tap-highlight-color: transparent;
   touch-action: manipulation;
+}
+
+.bookshelf-icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  line-height: 1;
 }

--- a/app/assets/stylesheets/_my_bookshelf_pc.scss
+++ b/app/assets/stylesheets/_my_bookshelf_pc.scss
@@ -123,7 +123,7 @@
 
   @media (min-width: 768px) {
   .no-cover  {
-    padding: 0px 4px; // タブレット・PC向け
+    padding: 0px 4px;
   }
 }
 
@@ -137,12 +137,12 @@
   word-break: break-word;
   width: 100%;
   margin-top: 0.8rem;
-  font-size: 0.66rem; // デフォルトはモバイル想定
+  font-size: 0.66rem;
 }
 
 @media (min-width: 768px) {
   .no-cover .title {
-    font-size: 0.95rem; // タブレット・PC向け
+    font-size: 0.95rem;
   }
 }
 

--- a/app/assets/stylesheets/_my_bookshelf_pc.scss
+++ b/app/assets/stylesheets/_my_bookshelf_pc.scss
@@ -46,6 +46,18 @@
   height: auto;
   margin-bottom: -2.8px;
   z-index: 2;
+  transition: transform 0.28s cubic-bezier(0.25, 0.8, 0.25, 1), box-shadow 0.3s ease;
+}
+
+.book-on-shelf:hover {
+  transform: translateY(-9px) scale(1.04);
+  z-index: 3;
+}
+
+.book-on-shelf:hover .book-cover,
+.book-on-shelf:hover .no-cover {
+  box-shadow: 0 12px 16px rgba(0, 0, 0, 0.25);
+  transition: box-shadow 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .book-cover {

--- a/app/assets/stylesheets/_spine.scss
+++ b/app/assets/stylesheets/_spine.scss
@@ -16,6 +16,13 @@
   border-radius: 0.25rem;
   transition: all 0.3s ease;
   z-index: 1;
+
+  @media(min-width: 1200px) {
+    width: 48px;
+  }
+  @media(min-width: 700px) {
+  width: 40px;
+  }
 }
 
 .spine-title {
@@ -23,6 +30,7 @@
   white-space: nowrap;
   line-height: 1.4;
   z-index: 2;
+  font-weight: 600;
 }
 
 /* 拡大中の背表紙 */
@@ -80,7 +88,7 @@
   z-index: 2;
 
   @media(max-width: 572px){
-    gap: 4px;
+    gap: 0px;
   }
 }
 
@@ -125,7 +133,7 @@
 .spine-brand {
   position: absolute;
   bottom: 6px;
-  right: 8px;
+  right: 7px;
   font-size: 0.35rem;
   writing-mode: horizontal-tb;
   font-weight: 700;
@@ -134,6 +142,10 @@
   letter-spacing: 0.06em;
   pointer-events: none;
   user-select: none;
+
+  @media(min-width: 1200px) {
+    right: 12px;
+  }
 }
 
 .spine-top-bar {

--- a/app/assets/stylesheets/_spine.scss
+++ b/app/assets/stylesheets/_spine.scss
@@ -176,10 +176,8 @@
   letter-spacing: 0.06em;
   pointer-events: none;
   user-select: none;
-
-  @media(min-width: 1200px) {
-    right: 9px;
-  }
+  @media(min-width: 700px) { right: 8.5px; }
+  @media(min-width: 1200px) { right: 9px;}
 }
 
 /* === 棚の並び === */

--- a/app/assets/stylesheets/_spine.scss
+++ b/app/assets/stylesheets/_spine.scss
@@ -1,11 +1,12 @@
+/* === Base 背表紙ブロック === */
 .spine-on-shelf {
   width: 36px;
   height: 150px;
-  background: #f5d75b;
+  background: linear-gradient(to right, #f5d75b 0%, #f5d75b 60%, #eacb42 100%);
   margin-right: 4px;
   writing-mode: vertical-rl;
   text-align: center;
-  position: relative; /* ここが重要！内部拡大表示の基準 */
+  position: relative;
   cursor: pointer;
   overflow: hidden;
   display: flex;
@@ -15,16 +16,79 @@
   padding-bottom: 8px;
   border-radius: 0.25rem;
   transition: all 0.3s ease;
+  box-shadow:
+    inset -1px 0 1px rgba(0, 0, 0, 0.04),
+    1px 2px 4px rgba(0, 0, 0, 0.1);
   z-index: 1;
 
-  @media(min-width: 1200px) {
-    width: 48px;
+  @media(min-width: 1200px) { width: 48px; }
+  @media(min-width: 700px) { width: 40px; }
+
+  /* 光沢ハイライト */
+  &::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(
+      120deg,
+      rgba(255, 255, 255, 0.06) 0%,
+      rgba(255, 255, 255, 0.03) 40%,
+      transparent 80%
+    );
+    pointer-events: none;
+    z-index: 1;
   }
-  @media(min-width: 700px) {
-  width: 40px;
+
+  /* 側面の厚み表現 */
+  &::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: -4px;
+    width: 4px;
+    height: 100%;
+    background: linear-gradient(
+      to bottom,
+      #e3c23e,
+      #d6b63a
+    );
+    transform: skewY(-4deg);
+    filter: blur(0.2px);
+    z-index: 0;
+    border-top-right-radius: 0.25rem;
+    border-bottom-right-radius: 0.25rem;
+  }
+
+  &:hover {
+    transform: translateY(-4px) scale(1.02);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+    z-index: 5;
+  }
+
+  &.expanded {
+    z-index: 20;
+
+    &.with-cover {
+      width: 105px;
+      height: 150px;
+    }
+
+    .spine-cover-image {
+      opacity: 1;
+      transform: translate(-50%, -50%) scale(0.8);
+      pointer-events: auto;
+    }
+
+    .spine-title {
+      display: none;
+    }
   }
 }
 
+/* === テキスト表示 === */
 .spine-title {
   font-size: 0.75rem;
   white-space: nowrap;
@@ -33,13 +97,15 @@
   font-weight: 600;
 }
 
-/* 拡大中の背表紙 */
-.spine-on-shelf.expanded {
-  z-index: 20;
+.expanded-title {
+  font-size: 1.2rem;
+  writing-mode: horizontal-tb;
+  margin-top: 1rem;
+  z-index: 2;
 }
 
 /* カバー画像 */
-.spine-on-shelf .spine-cover-image {
+.spine-cover-image {
   position: absolute;
   top: 50%;
   left: 50%;
@@ -55,48 +121,7 @@
   pointer-events: none;
 }
 
-/* 拡大時に画像を表示 */
-.spine-on-shelf.expanded .spine-cover-image {
-  opacity: 1;
-  transform: translate(-50%, -50%) scale(0.8);
-  pointer-events: auto;
-}
-
-/* 拡大時はタイトル非表示 */
-.spine-on-shelf.expanded .spine-title {
-  display: none;
-}
-
-/* カバー画像がない場合に表示する拡大タイトル */
-.expanded-title {
-  font-size: 1.2rem;
-  writing-mode: horizontal-tb;
-  margin-top: 1rem;
-  z-index: 2;
-}
-
-/* 各行の棚表示 */
-.book-spine-row {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 12px;
-  max-width: 94%;
-  min-width: 94%;
-  padding: 0 8px;
-  margin-bottom: -0.075rem;
-  z-index: 2;
-
-  @media(max-width: 572px){
-    gap: 0px;
-  }
-}
-
-.spine-on-shelf.expanded.with-cover {
-  width: 105px;
-  height: 150px; /* 元のまま */
-}
-
+/* カバーなし用の中身 */
 .spine-no-cover {
   width: 94%;
   height: 100%;
@@ -112,12 +137,21 @@
   text-align: center;
   font-weight: bold;
 }
-.spine-on-shelf:hover {
-  transform: translateY(-4px) scale(1.02);
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
-  z-index: 5;
+
+/* 上部バー装飾 */
+.spine-top-bar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 6px;
+  background: #11111176;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+  border-top-left-radius: 0.25rem;
+  border-top-right-radius: 0.25rem;
 }
 
+/* 下部バッジ・ロゴ */
 .spine-badge {
   position: absolute;
   bottom: 4px;
@@ -132,7 +166,7 @@
 
 .spine-brand {
   position: absolute;
-  bottom: 6px;
+  bottom: 1px;
   right: 7px;
   font-size: 0.35rem;
   writing-mode: horizontal-tb;
@@ -144,18 +178,23 @@
   user-select: none;
 
   @media(min-width: 1200px) {
-    right: 12px;
+    right: 9px;
   }
 }
 
-.spine-top-bar {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 6px;
-  background: #11111176;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
-  border-top-left-radius: 0.25rem;
-  border-top-right-radius: 0.25rem;
+/* === 棚の並び === */
+.book-spine-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 2px;
+  max-width: 94%;
+  min-width: 94%;
+  padding: 0 8px;
+  margin-bottom: -0.2px;
+  z-index: 2;
+
+  @media(max-width: 572px) {
+    gap: 0px;
+  }
 }

--- a/app/assets/stylesheets/_spine.scss
+++ b/app/assets/stylesheets/_spine.scss
@@ -1,0 +1,149 @@
+.spine-on-shelf {
+  width: 36px;
+  height: 150px;
+  background: #f5d75b;
+  margin-right: 4px;
+  writing-mode: vertical-rl;
+  text-align: center;
+  position: relative; /* ここが重要！内部拡大表示の基準 */
+  cursor: pointer;
+  overflow: hidden;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  border-radius: 0.25rem;
+  transition: all 0.3s ease;
+  z-index: 1;
+}
+
+.spine-title {
+  font-size: 0.75rem;
+  white-space: nowrap;
+  line-height: 1.4;
+  z-index: 2;
+}
+
+/* 拡大中の背表紙 */
+.spine-on-shelf.expanded {
+  z-index: 20;
+}
+
+/* カバー画像 */
+.spine-on-shelf .spine-cover-image {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 120px;
+  height: auto;
+  transform: translate(-50%, -50%) scale(1);
+  object-fit: contain;
+  border-radius: 0.25rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+  opacity: 0;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  z-index: 10;
+  pointer-events: none;
+}
+
+/* 拡大時に画像を表示 */
+.spine-on-shelf.expanded .spine-cover-image {
+  opacity: 1;
+  transform: translate(-50%, -50%) scale(0.8);
+  pointer-events: auto;
+}
+
+/* 拡大時はタイトル非表示 */
+.spine-on-shelf.expanded .spine-title {
+  display: none;
+}
+
+/* カバー画像がない場合に表示する拡大タイトル */
+.expanded-title {
+  font-size: 1.2rem;
+  writing-mode: horizontal-tb;
+  margin-top: 1rem;
+  z-index: 2;
+}
+
+/* 各行の棚表示 */
+.book-spine-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 12px;
+  max-width: 94%;
+  min-width: 94%;
+  padding: 0 8px;
+  margin-bottom: -0.075rem;
+  z-index: 2;
+
+  @media(max-width: 572px){
+    gap: 4px;
+  }
+}
+
+.spine-on-shelf.expanded.with-cover {
+  width: 105px;
+  height: 150px; /* 元のまま */
+}
+
+.spine-no-cover {
+  width: 94%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  writing-mode: horizontal-tb;
+  align-items: flex-start;
+  padding-top: 8px;
+  font-size: 0.75rem;
+  text-orientation: mixed;
+  background: #f5d75b;
+  border-radius: 0.25rem;
+  text-align: center;
+  font-weight: bold;
+}
+.spine-on-shelf:hover {
+  transform: translateY(-4px) scale(1.02);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+  z-index: 5;
+}
+
+.spine-badge {
+  position: absolute;
+  bottom: 4px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 0.75rem;
+  color: #333;
+  opacity: 0.7;
+  z-index: 3;
+  pointer-events: none;
+}
+
+.spine-brand {
+  position: absolute;
+  bottom: 6px;
+  right: 8px;
+  font-size: 0.35rem;
+  writing-mode: horizontal-tb;
+  font-weight: 700;
+  font-family: "Big Shoulders Inline", sans-serif;
+  color: rgba(0, 0, 0, 0.786);
+  letter-spacing: 0.06em;
+  pointer-events: none;
+  user-select: none;
+}
+
+.spine-top-bar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 6px;
+  background: #11111176;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+  border-top-left-radius: 0.25rem;
+  border-top-right-radius: 0.25rem;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,6 +16,7 @@
 @import "pagination";
 @import "starters";
 @import "table";
+@import "spine";
 
 
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -42,7 +42,7 @@ class ApplicationController < ActionController::Base
     case
     when browser.device.mobile? then 7
     when browser.device.tablet? then 14
-    else 20
+    else 21
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::Base
   allow_browser versions: :modern
   protect_from_forgery with: :exception
   before_action :configure_permitted_parameters, if: :devise_controller?
-  helper_method :guest_user, :mobile?, :default_books_per_shelf, :default_card_columns
+  helper_method :guest_user, :mobile?, :default_books_per_shelf, :default_card_columns, :default_spine_per_shelf
 
 
   def guest_user
@@ -35,6 +35,14 @@ class ApplicationController < ActionController::Base
     when browser.device.mobile? then 5
     when browser.device.tablet? then 8
     else 10
+    end
+  end
+
+  def default_spine_per_shelf
+    case
+    when browser.device.mobile? then 7
+    when browser.device.tablet? then 14
+    else 20
     end
   end
 

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -32,12 +32,23 @@ class BooksController < ApplicationController
     books_per_page = display.unit_per_page * CHUNKS_PER_PAGE
     @pagy, @books = pagy(books, limit: books_per_page)
 
-    if @view_mode == "shelf" && turbo_frame_request?
-      render partial: "bookshelf/kino_chunk", locals: {
-        books: @books,
-        books_per_shelf: @books_per_shelf,
-        pagy: @pagy
-      }, layout: false
+    if turbo_frame_request?
+      case @view_mode
+      when "shelf"
+        render partial: "bookshelf/kino_chunk", locals: {
+          books: @books,
+          books_per_shelf: @books_per_shelf,
+          pagy: @pagy
+        }, layout: false
+      when "spine"
+        render partial: "bookshelf/spine_chunk", locals: {
+          books: @books,
+          spine_per_shelf: @spine_per_shelf,
+          pagy: @pagy
+        }, layout: false
+      else
+        render :index
+      end
     else
       render :index
     end

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -17,13 +17,15 @@ class BooksController < ApplicationController
     display = BooksDisplaySetting.new(session, params, {
       shelf: default_books_per_shelf,
       card: default_card_columns,
-      detail_card: default_detail_card_columns
+      detail_card: default_detail_card_columns,
+      spine: default_spine_per_shelf
     }, mobile: mobile?)
 
     @view_mode = display.view_mode
     @books_per_shelf = display.books_per_shelf
     @card_columns = display.card_columns
     @detail_card_columns = display.detail_card_columns
+    @spine_per_shelf = display.spine_per_shelf
 
     books = BooksQuery.new(books, params: params, current_user: current_user).call
 

--- a/app/controllers/guest/books_controller.rb
+++ b/app/controllers/guest/books_controller.rb
@@ -16,13 +16,15 @@ module Guest
       display = BooksDisplaySetting.new(session, params, {
         shelf: default_books_per_shelf,
         card: default_card_columns,
-        detail_card: default_detail_card_columns
+        detail_card: default_detail_card_columns,
+        spine: default_spine_per_shelf
         }, mobile: mobile?)
 
       @view_mode       = display.view_mode
       @books_per_shelf = display.books_per_shelf
       @card_columns    = display.card_columns
       @detail_card_columns = display.detail_card_columns
+      @spine_per_shelf = display.spine_per_shelf
 
       books_per_page = display.unit_per_page * CHUNKS_PER_PAGE
       @pagy, @books = pagy(books, limit: books_per_page)

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -15,6 +15,7 @@ import InfiniteScrollController from "./controllers/infinite_scroll_controller.j
 import SafariClickFixController from "./controllers/safari_click_fix_controller.js"
 import DetailCardColumnSelectorController from "./controllers/detail_card_column_selector_controller.js"
 import BookEditController from "./controllers/book_edit_controller.js"
+import SpineBookController from "./controllers/spine_book_controller.js"
 
 const application = Application.start()
 window.Stimulus = application
@@ -35,6 +36,7 @@ application.register("infinite-scroll", InfiniteScrollController)
 application.register("safari-click-fix", SafariClickFixController)
 application.register("detail-card-column-selector", DetailCardColumnSelectorController)
 application.register("book-edit", BookEditController)
+application.register("spine-book", SpineBookController)
 
 import * as bootstrap from "bootstrap"
 window.bootstrap = bootstrap  // グローバルにしたい場合

--- a/app/javascript/controllers/spine_book_controller.js
+++ b/app/javascript/controllers/spine_book_controller.js
@@ -1,0 +1,69 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["title", "cover"]
+  static values = { linkUrl: String }
+
+  connect() {
+    this.expanded = false
+    this.handleDocumentClick = this.handleDocumentClick.bind(this)
+    this.handleEscape = this.handleEscape.bind(this)
+  }
+
+  handleClick(event) {
+    if (!this.expanded) {
+      this.expand()
+    } else {
+      window.location.href = this.linkUrlValue
+    }
+  }
+
+  expand() {
+    this.expanded = true
+    this.element.classList.add("expanded")
+
+    if (this.hasCoverTarget) {
+      this.element.classList.add("with-cover")
+      this.coverTarget.classList.remove("d-none")
+      this.titleTarget.classList.add("d-none")
+    } else {
+      this.titleTarget.classList.add("expanded-title")
+    }
+
+    document.addEventListener("click", this.handleDocumentClick)
+    document.addEventListener("keydown", this.handleEscape)
+  }
+
+  collapse() {
+    this.expanded = false
+    this.element.classList.remove("expanded", "with-cover")
+    this.element.classList.remove("expanded")
+
+    if (this.hasCoverTarget) {
+      this.coverTarget.classList.add("d-none")
+      this.titleTarget.classList.remove("d-none")
+    } else {
+      this.titleTarget.classList.remove("expanded-title")
+    }
+
+    document.removeEventListener("click", this.handleDocumentClick)
+    document.removeEventListener("keydown", this.handleEscape)
+  }
+
+  handleDocumentClick(event) {
+    if (!this.element.contains(event.target)) {
+      this.collapse()
+    }
+  }
+
+  handleEscape(event) {
+    if (event.key === "Escape") {
+      this.collapse()
+    }
+  }
+
+  disconnect() {
+    document.removeEventListener("click", this.handleDocumentClick)
+    document.removeEventListener("keydown", this.handleEscape)
+  }
+}

--- a/app/queries/books_query.rb
+++ b/app/queries/books_query.rb
@@ -10,6 +10,7 @@ class BooksQuery
   def call
     books = filter_by_tags(@books)
     books = filter_by_status(books)
+    books = filter_by_memo_visibility(books)
     books = apply_sorting(books)
   end
 
@@ -26,6 +27,19 @@ class BooksQuery
     return books unless @params[:status].present? && Book.statuses.key?(@params[:status])
 
     books.where(status: @params[:status])
+  end
+
+
+  def filter_by_memo_visibility(books)
+    return books unless @params[:memo_visibility].present?
+
+    visibility = Memo::VISIBILITY[@params[:memo_visibility].to_sym]
+    return books unless visibility
+
+    books
+      .joins(:memos)
+      .where(memos: { visibility: visibility })
+      .distinct
   end
 
   def apply_sorting(books)

--- a/app/services/books_display_setting.rb
+++ b/app/services/books_display_setting.rb
@@ -5,6 +5,7 @@ class BooksDisplaySetting
   SHELF_PER_KEY           = :shelf_per
   CARD_COLUMNS_KEY        = :card_columns
   DETAIL_CARD_COLUMNS_KEY = :detail_card_columns
+  SPINE_PER_KEY           = :spine_per
 
   attr_reader :view_mode, :unit_per_page, :books_per_shelf,
               :card_columns, :detail_card_columns, :spine_per_shelf
@@ -43,8 +44,10 @@ class BooksDisplaySetting
     when "b_note"
       @unit_per_page = 7.2
     when "spine"
-      @spine_per_shelf = @defaults[:spine]
+      @session[SPINE_PER_KEY] = @params[:per_spine] if @params[:per_spine].present?
+      @spine_per_shelf = @session[SPINE_PER_KEY]&.to_i || @defaults[:spine]
       @unit_per_page = @spine_per_shelf
+
     else
       @unit_per_page = @defaults[:shelf]
 

--- a/app/services/books_display_setting.rb
+++ b/app/services/books_display_setting.rb
@@ -6,8 +6,8 @@ class BooksDisplaySetting
   CARD_COLUMNS_KEY        = :card_columns
   DETAIL_CARD_COLUMNS_KEY = :detail_card_columns
 
-  attr_reader :view_mode, :unit_per_page,
-              :books_per_shelf, :card_columns, :detail_card_columns
+  attr_reader :view_mode, :unit_per_page, :books_per_shelf,
+              :card_columns, :detail_card_columns, :spine_per_shelf
 
   def initialize(session, params, defaults, mobile: false)
     @session = session
@@ -42,8 +42,12 @@ class BooksDisplaySetting
       @unit_per_page = @mobile ? @detail_card_columns * 4 : @detail_card_columns
     when "b_note"
       @unit_per_page = 7.2
+    when "spine"
+      @spine_per_shelf = @defaults[:spine]
+      @unit_per_page = @spine_per_shelf
     else
       @unit_per_page = @defaults[:shelf]
+
     end
   end
 end

--- a/app/views/books/_status_filter.html.erb
+++ b/app/views/books/_status_filter.html.erb
@@ -1,11 +1,35 @@
+<% current_status = params[:status] %>
+<% current_visibility = params[:memo_visibility] %>
+
 <div class="d-flex justify-content-center">
   <div class="d-flex flex-wrap gap-2 px-3 py-2 bg-light-bok border rounded-pill shadow-sm align-items-center">
-  <% Book.statuses.each do |key, _| %>
-    <%= link_to t("books.status.#{key}"),
-                books_path(status: key, tags: params[:tags], sort: params[:sort]),
-                class: "btn btn-sm rounded-pill #{'btn-primary-bok' if current_status == key} btn-outline-secondary" %>
-  <% end %>
-  <%= link_to "すべて", books_path(tags: params[:tags], sort: params[:sort]),
-              class: "btn btn-sm btn-outline-dark rounded-pill" %>
+    <% Book.statuses.each do |key, _| %>
+      <%= link_to t("books.status.#{key}"),
+                  books_path(status: key, tags: params[:tags], sort: params[:sort], memo_visibility: current_visibility),
+                  class: "btn btn-sm rounded-pill #{'btn-primary-bok' if current_status == key.to_s} btn-outline-secondary",
+                  aria: (current_status == key.to_s ? { current: "true" } : {}) %>
+    <% end %>
+
+    <%= link_to "すべて",
+                books_path(tags: params[:tags], sort: params[:sort], memo_visibility: current_visibility),
+                class: "btn btn-sm btn-outline-dark rounded-pill",
+                aria: (current_status.nil? ? { current: "true" } : {}) %>
+  </div>
+</div>
+
+<div class="d-flex justify-content-center mt-2">
+  <div class="d-flex flex-wrap gap-2 px-3 py-2 bg-light-bok border rounded-pill shadow-sm align-items-center">
+    <% Memo::VISIBILITY.each do |key, _| %>
+      <% label = t("memos.visibility.#{key}", default: key.to_s.humanize) %>
+      <%= link_to label,
+                  books_path(memo_visibility: key, status: current_status, tags: params[:tags], sort: params[:sort]),
+                  class: "btn btn-sm rounded-pill #{'btn-success text-white' if current_visibility == key.to_s} btn-outline-secondary",
+                  aria: (current_visibility == key.to_s ? { current: "true" } : {}) %>
+    <% end %>
+
+    <%= link_to "すべて",
+                books_path(status: current_status, tags: params[:tags], sort: params[:sort]),
+                class: "btn btn-sm btn-outline-dark rounded-pill",
+                aria: (current_visibility.nil? ? { current: "true" } : {}) %>
   </div>
 </div>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -31,10 +31,12 @@
 
 
 <!-- 本棚 -->
-<%= render "bookshelf/books_frame_wrapper",
+<%# <%= render "bookshelf/books_frame_wrapper",
             books: @books,
             books_per_shelf: @books_per_shelf,
             pagy: @pagy,
             view_mode: @view_mode,
             card_columns: @card_columns
-%>
+%> %>
+
+<%= render "bookshelf/spine", books: @books, mobile: @moblie %>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -4,11 +4,11 @@
 
 <div class="d-flex align-items-center justify-content-between mt-4 mb-3 px-3">
   <% views = [
-    { key: "shelf",       icon: "bi-layout-three-columns",   title: "棚ビューに切り替え" },
-    { key: "card",        icon: "bi-card-text",              title: "カードビューに切り替え" },
-    { key: "detail_card", icon: "bi-layout-text-sidebar",    title: "詳細カードビューに切り替え" },
-    { key: "b_note",      icon: "bi-table",                  title: "B-noteビューに切り替え" },
-    { key: "spine",       icon: "bi-book-half",              title: "背表紙ビューに切り替え" }
+    { key: "shelf",       icon: "bi-bookshelf",               title: "棚ビューに切り替え" },
+    { key: "spine",       icon: "bi-layout-three-columns",    title: "背表紙ビューに切り替え" },
+    { key: "card",        icon: "bi-file",                    title: "カードビューに切り替え" },
+    { key: "detail_card", icon: "bi bi-layout-sidebar-inset", title: "詳細カードビューに切り替え" },
+    { key: "b_note",      icon: "bi-table",                   title: "B-noteビューに切り替え" }
   ] %>
 
   <% current_index = views.index { |v| v[:key] == @view_mode } || 0 %>
@@ -17,8 +17,7 @@
 
   <div class="flex-shrink-0">
     <%= link_to books_path(view: next_view[:key]),
-                class: "btn btn-light border shadow-sm d-flex align-items-center justify-content-center",
-                style: "width: 40px; height: 40px; border-radius: 50%; line-height: 1;",
+                class: "btn btn-light border shadow-sm d-flex align-items-center justify-content-center bookshelf-icon",
                 title: next_view[:title] do %>
       <i class="bi <%= current_icon %> fs-5 icon-refined"></i>
     <% end %>
@@ -28,7 +27,8 @@
   <%= render "books/filter_controlls",
               filtered_tag: @filtered_tag,
               filtered_tags: @filtered_tags,
-              filtered_status: @filtered_status %>
+              filtered_status: @filtered_status
+  %>
 
 
 <!-- 本棚 -->

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -7,7 +7,8 @@
     { key: "shelf",       icon: "bi-layout-three-columns",   title: "棚ビューに切り替え" },
     { key: "card",        icon: "bi-card-text",              title: "カードビューに切り替え" },
     { key: "detail_card", icon: "bi-layout-text-sidebar",    title: "詳細カードビューに切り替え" },
-    { key: "b_note",      icon: "bi-table",                  title: "B-noteビューに切り替え" }
+    { key: "b_note",      icon: "bi-table",                  title: "B-noteビューに切り替え" },
+    { key: "spine",       icon: "bi-book-half",              title: "背表紙ビューに切り替え" }
   ] %>
 
   <% current_index = views.index { |v| v[:key] == @view_mode } || 0 %>
@@ -31,12 +32,11 @@
 
 
 <!-- 本棚 -->
-<%# <%= render "bookshelf/books_frame_wrapper",
+<%= render "bookshelf/books_frame_wrapper",
             books: @books,
             books_per_shelf: @books_per_shelf,
             pagy: @pagy,
             view_mode: @view_mode,
-            card_columns: @card_columns
-%> %>
-
-<%= render "bookshelf/spine", books: @books, mobile: @moblie %>
+            card_columns: @card_columns,
+            spine_per_shelf: @spine_per_shelf
+%>

--- a/app/views/bookshelf/_books_frame_wrapper.html.erb
+++ b/app/views/bookshelf/_books_frame_wrapper.html.erb
@@ -18,6 +18,7 @@
     <%= render "bookshelf/b_note", books: books, pagy: pagy %>
 
   <% when "spine" %>
+    <%= render "bookshelf/spine_select_numbers", spine_per_shelf: spine_per_shelf %>
     <%= render "bookshelf/spine", books: books, pagy: pagy, spine_per_shelf: spine_per_shelf %>
   <% end %>
 </turbo-frame>

--- a/app/views/bookshelf/_books_frame_wrapper.html.erb
+++ b/app/views/bookshelf/_books_frame_wrapper.html.erb
@@ -16,5 +16,8 @@
 
   <% when "b_note" %>
     <%= render "bookshelf/b_note", books: books, pagy: pagy %>
+
+  <% when "spine" %>
+    <%= render "bookshelf/spine", books: books, pagy: pagy, spine_per_shelf: spine_per_shelf %>
   <% end %>
 </turbo-frame>

--- a/app/views/bookshelf/_kino_chunk.html.erb
+++ b/app/views/bookshelf/_kino_chunk.html.erb
@@ -4,5 +4,5 @@
 
 <!-- タグ・フィルター用 -->
 <turbo-frame id="books_frame">
-  <%= render partial: "bookshelf/kino_books_grid", locals: { books: books, books_per_shelf: books_per_shelf, pagy: pagy } %>
+  <%= render "bookshelf/kino_books_grid", books: books, books_per_shelf: books_per_shelf, pagy: pagy %>
 </turbo-frame>

--- a/app/views/bookshelf/_simple_card.html.erb
+++ b/app/views/bookshelf/_simple_card.html.erb
@@ -36,8 +36,6 @@
   <%= hidden_field_tag :column, card_columns, id: "hiddenColumnInput" %>
 <% end %>
 
-
-
 <% if pagy %>
   <div class="my-5 d-flex justify-content-center">
     <%== pagy_bootstrap_nav(pagy) %>

--- a/app/views/bookshelf/_spine.html.erb
+++ b/app/views/bookshelf/_spine.html.erb
@@ -37,8 +37,14 @@
   </div>
 <% end %>
 
-<% if pagy %>
-  <div class="my-5 d-flex justify-content-center">
-    <%== pagy_bootstrap_nav(pagy) %>
-  </div>
+<% if pagy && pagy.next %>
+  <turbo-frame id="next_books"
+                src="<%= books_path(view: 'spine', page: pagy.next) %>"
+                loading="lazy"
+                data-controller="lazy-load"
+                data-lazy-load-url-value="<%= books_path(view: 'spine', page: pagy.next) %>">
+    <div class="text-center my-4">
+      <div class="spinner-border text-secondary" role="status"></div>
+    </div>
+  </turbo-frame>
 <% end %>

--- a/app/views/bookshelf/_spine.html.erb
+++ b/app/views/bookshelf/_spine.html.erb
@@ -1,5 +1,5 @@
 
-<% books.each_slice(7) do |row_books| %>
+<% books.each_slice(spine_per_shelf) do |row_books| %>
   <div class="shelf-row position-relative">
     <div class="book-spine-row d-flex">
       <% row_books.each do |book| %>
@@ -34,5 +34,11 @@
     </div>
     <div class="shelf-bar"></div>
     <div class="shelf-depth"></div>
+  </div>
+<% end %>
+
+<% if pagy %>
+  <div class="my-5 d-flex justify-content-center">
+    <%== pagy_bootstrap_nav(pagy) %>
   </div>
 <% end %>

--- a/app/views/bookshelf/_spine.html.erb
+++ b/app/views/bookshelf/_spine.html.erb
@@ -1,0 +1,38 @@
+
+<% books.each_slice(7) do |row_books| %>
+  <div class="shelf-row position-relative">
+    <div class="book-spine-row d-flex">
+      <% row_books.each do |book| %>
+        <div class="spine-on-shelf"
+            data-controller="spine-book"
+            data-action="click->spine-book#handleClick"
+            data-spine-book-link-url-value="<%= book_link_path(book) %>">
+          <div class="spine-top-bar"></div>
+          <% if book.book_cover_s3.attached? %>
+            <%= image_tag book.book_cover_s3.variant(resize_to_limit: [240, 320]),
+                  alt: book.title,
+                  class: "spine-cover-image d-none",
+                  loading: "lazy",
+                  data: { spine_book_target: "cover" } %>
+          <% elsif book.book_cover.present? %>
+            <img src="<%= book.book_cover %>" alt="表紙画像"
+                class="spine-cover-image d-none"
+                data-spine-book-target="cover">
+          <% else %>
+            <div class="no-cover spine-no-cover shadow-lg d-none"
+                  data-spine-book-target="cover">
+              <%= book.title.truncate(10) %>
+            </div>
+          <% end %>
+
+            <div class="spine-title" data-spine-book-target="title">
+              <%= book.title.truncate(11) %>
+            </div>
+            <div class="spine-brand">Bokrium</div>
+          </div>
+      <% end %>
+    </div>
+    <div class="shelf-bar"></div>
+    <div class="shelf-depth"></div>
+  </div>
+<% end %>

--- a/app/views/bookshelf/_spine_chunk.html.erb
+++ b/app/views/bookshelf/_spine_chunk.html.erb
@@ -1,3 +1,8 @@
 <turbo-frame id="next_books">
   <%= render "bookshelf/spine", books: books, pagy: pagy, spine_per_shelf: spine_per_shelf %>
 </turbo-frame>
+
+<!-- タグ・フィルター用 -->
+<turbo-frame id="books_frame">
+  <%= render "bookshelf/spine", books: books, spine_per_shelf: spine_per_shelf, pagy: pagy %>
+</turbo-frame>

--- a/app/views/bookshelf/_spine_chunk.html.erb
+++ b/app/views/bookshelf/_spine_chunk.html.erb
@@ -1,0 +1,3 @@
+<turbo-frame id="next_books">
+  <%= render "bookshelf/spine", books: books, pagy: pagy, spine_per_shelf: spine_per_shelf %>
+</turbo-frame>

--- a/app/views/bookshelf/_spine_select_numbers.html.erb
+++ b/app/views/bookshelf/_spine_select_numbers.html.erb
@@ -1,0 +1,17 @@
+<%= form_with url: books_index_path, method: :get,
+              data: { controller: "auto-submit", turbo: false },
+              local: true,
+              class: "ms-3" do %>
+
+  <%= hidden_field_tag :view, "spine" %>
+
+  <% options = mobile? ? [7, 14] : [14, 21, 28, 35] %>
+
+  <%= select_tag :per_spine,
+      options_for_select(options, spine_per_shelf),
+      class: "form-select form-select-sm text-secondary shadow-sm books-per-shelf",
+      data: {
+        auto_submit_target: "select",
+        action: "change->auto-submit#change"
+      } %>
+<% end %>

--- a/app/views/guest/books/index.html.erb
+++ b/app/views/guest/books/index.html.erb
@@ -8,7 +8,8 @@
     { key: "shelf",       icon: "bi-layout-three-columns",   title: "棚ビューに切り替え" },
     { key: "card",        icon: "bi-card-text",              title: "カードビューに切り替え" },
     { key: "detail_card", icon: "bi-layout-text-sidebar",    title: "詳細カードビューに切り替え" },
-    { key: "b_note",      icon: "bi-table",                  title: "B-noteビューに切り替え" }
+    { key: "b_note",      icon: "bi-table",                  title: "B-noteビューに切り替え" },
+    { key: "spine",       icon: "bi-book-half",              title: "背表紙ビューに切り替え" }
   ] %>
 
   <% current_index = views.index { |v| v[:key] == @view_mode } || 0 %>
@@ -70,4 +71,7 @@
 
 <% when "b_note" %>
   <%= render "guest/bookshelf/b_note", books: @books, detail_card_columns: @detail_card_columns, pagy: @pagy %>
+
+<% when "spine" %>
+  <%= render "guest/bookshelf/spine", books: @books, pagy: @pagy, spine_per_shelf: @spine_per_shelf %>
 <% end %>

--- a/app/views/guest/books/index.html.erb
+++ b/app/views/guest/books/index.html.erb
@@ -5,11 +5,11 @@
 
 <div class="d-flex align-items-center justify-content-between mt-4 mb-3 px-3">
   <% views = [
-    { key: "shelf",       icon: "bi-layout-three-columns",   title: "棚ビューに切り替え" },
-    { key: "card",        icon: "bi-card-text",              title: "カードビューに切り替え" },
-    { key: "detail_card", icon: "bi-layout-text-sidebar",    title: "詳細カードビューに切り替え" },
-    { key: "b_note",      icon: "bi-table",                  title: "B-noteビューに切り替え" },
-    { key: "spine",       icon: "bi-book-half",              title: "背表紙ビューに切り替え" }
+    { key: "shelf",       icon: "bi-bookshelf",   title: "棚ビューに切り替え" },
+    { key: "spine",       icon: "bi-layout-three-columns",              title: "背表紙ビューに切り替え" },
+    { key: "card",        icon: "bi-file",              title: "カードビューに切り替え" },
+    { key: "detail_card", icon: "bi bi-layout-sidebar-inset",    title: "詳細カードビューに切り替え" },
+    { key: "b_note",      icon: "bi-table",                  title: "B-noteビューに切り替え" }
   ] %>
 
   <% current_index = views.index { |v| v[:key] == @view_mode } || 0 %>

--- a/app/views/guest/bookshelf/_spine.html.erb
+++ b/app/views/guest/bookshelf/_spine.html.erb
@@ -1,0 +1,38 @@
+
+<% books.each_slice(spine_per_shelf) do |row_books| %>
+  <div class="shelf-row position-relative">
+    <div class="book-spine-row d-flex">
+      <% row_books.each do |book| %>
+        <div class="spine-on-shelf"
+            data-controller="spine-book"
+            data-action="click->spine-book#handleClick"
+            data-spine-book-link-url-value="<%= book_link_path(book) %>">
+          <div class="spine-top-bar"></div>
+          <% if book.book_cover_s3.attached? %>
+            <%= image_tag book.book_cover_s3.variant(resize_to_limit: [240, 320]),
+                  alt: book.title,
+                  class: "spine-cover-image d-none",
+                  loading: "lazy",
+                  data: { spine_book_target: "cover" } %>
+          <% elsif book.book_cover.present? %>
+            <img src="<%= book.book_cover %>" alt="表紙画像"
+                class="spine-cover-image d-none"
+                data-spine-book-target="cover">
+          <% else %>
+            <div class="no-cover spine-no-cover shadow-lg d-none"
+                  data-spine-book-target="cover">
+              <%= book.title.truncate(10) %>
+            </div>
+          <% end %>
+
+            <div class="spine-title" data-spine-book-target="title">
+              <%= book.title.truncate(11) %>
+            </div>
+            <div class="spine-brand">Bokrium</div>
+          </div>
+      <% end %>
+    </div>
+    <div class="shelf-bar"></div>
+    <div class="shelf-depth"></div>
+  </div>
+<% end %>

--- a/app/views/guest/bookshelf/_spine.html.erb
+++ b/app/views/guest/bookshelf/_spine.html.erb
@@ -1,3 +1,20 @@
+<%= form_with url: books_index_path, method: :get,
+              data: { controller: "auto-submit", turbo: false },
+              local: true,
+              class: "ms-3" do %>
+
+  <%= hidden_field_tag :view, "spine" %>
+
+  <% options = mobile? ? [7, 14] : [14, 21, 28, 35] %>
+
+  <%= select_tag :per_spine,
+      options_for_select(options, spine_per_shelf),
+      class: "form-select form-select-sm text-secondary shadow-sm books-per-shelf",
+      data: {
+        auto_submit_target: "select",
+        action: "change->auto-submit#change"
+      } %>
+<% end %>
 
 <% books.each_slice(spine_per_shelf) do |row_books| %>
   <div class="shelf-row position-relative">

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -12,9 +12,10 @@ ja:
       reading: "読書中"
       finished: "読了"
   memos:
-    published:
-      only_i_can_see: "非公開"
-      you_can_see: "公開"
+    visibility:
+      only_me: 非公開
+      link_only: リンク限定
+      public_site: 公開
   placeholders:
     isbn: "9781234567890"
     author: "村上春樹"


### PR DESCRIPTION
### 概要

本棚に「背表紙ビュー」を新たに追加し、以下のような体験と機能の向上を行いました。

### 主な変更点

- 背表紙ビュー（Spine view）を新規実装し、レクラム風のレイアウト＆装飾を追加
- 背表紙ビュー（spine）をビュー切り替えに追加し、デバイスごとの表示冊数を調整（per_spine対応）
-  ゲストユーザーにも背表紙ビューを提供
- 背表紙ビューでも表示冊数の切り替えが可能に（セレクトボックス付き）
- 背表紙ビューに無限スクロールを導入（Turbo + Stimulus）
- 各ビューの切り替えアイコンを、より直感的なBootstrap Iconsに変更

### その他の改善

- Implement: LINE通知処理でDB接続エラー時にリトライするよう対応（安定性向上）
