### PR TITLE
UI/sign in and up

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,8 +15,8 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [ :name, :introduction, :avatar_s3 ])
-    devise_parameter_sanitizer.permit(:account_update, keys: [ :name, :introduction, :avatar_s3 ])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [ :name, :avatar_s3 ])
+    devise_parameter_sanitizer.permit(:account_update, keys: [ :name, :avatar_s3 ])
   end
 
   private
@@ -51,14 +51,5 @@ class ApplicationController < ActionController::Base
 
   def default_detail_card_columns
     mobile? ? 1 : 6
-  end
-
-
-  def limit_error_stream(id:, message:)
-    turbo_stream.replace(
-      id,
-      partial: "shared/limit_reached_message",
-      locals: { dom_id: id, message: message }
-    )
   end
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -3,29 +3,58 @@
     <div class="col-md-6 col-lg-5">
       <div class="card shadow-sm">
         <div class="card-body">
-          <h2 class="mb-4 text-center"><%= t('.sign_up') %></h2>
+          <h1 class="fw-bold big-shoulders-inline-bold mb-4 text-center">
+            <span class="logo-welcome" title="ボクリウム">Bokrium</span>
+          </h1>
 
           <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "needs-validation", novalidate: true }) do |f| %>
             <%= render "devise/shared/error_messages", resource: resource %>
 
-            <div class="mb-3">
-              <%= f.label :email, class: "form-label" %>
-              <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control", required: true %>
+            <div class="form-floating mb-3">
+              <%= f.text_field :name,
+                    class: "form-control",
+                    id: "floatingName",
+                    placeholder: "name" %>
+              <%= f.label :name, for: "floatingName" %>
             </div>
 
-            <div class="mb-3">
-              <%= f.label :password, class: "form-label" %>
-              <% if @minimum_password_length %>
-                <div class="form-text mb-1">
-                  <%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %>
-                </div>
+            <div class="form-floating mb-3">
+              <%= f.email_field :email,
+                    autofocus: true,
+                    autocomplete: "email",
+                    class: "form-control",
+                    id: "floatingEmail",
+                    placeholder: "メールアドレス",
+                    required: true %>
+              <%= f.label :email, for: "floatingEmail" do %>
+                メールアドレス <span class="text-danger">*</span>
               <% end %>
-              <%= f.password_field :password, autocomplete: "new-password", class: "form-control", required: true %>
             </div>
 
-            <div class="mb-3">
-              <%= f.label :password_confirmation, class: "form-label" %>
-              <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control", required: true %>
+            <% if @minimum_password_length %>
+              <div class="form-floating mb-3">
+                <%= f.password_field :password,
+                      autocomplete: "new-password",
+                      class: "form-control",
+                      id: "floatingPassword",
+                      placeholder: "password",
+                      required: true %>
+                <%= f.label :password, for: "floatingPassword" do %>
+                  パスワード（<%= @minimum_password_length %>文字以上） <span class="text-danger">*</span>
+                <% end %>
+              </div>
+            <% end %>
+
+            <div class="form-floating mb-3">
+              <%= f.password_field :password_confirmation,
+                    autocomplete: "new-password",
+                    class: "form-control",
+                    id: "floatingPasswordConfirmation",
+                    placeholder: "password_confirmation",
+                    required: true %>
+              <%= f.label :password_confirmation, for: "floatingPasswordConfirmation" do %>
+                パスワード確認 <span class="text-danger">*</span>
+              <% end %>
             </div>
 
             <div class="d-grid mb-3">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -3,21 +3,33 @@
     <div class="col-md-6 col-lg-5">
       <div class="card shadow-sm">
         <div class="card-body">
-          <h2 class="mb-4 text-center"><%= t('.sign_in') %></h2>
+          <h1 class="fw-bold big-shoulders-inline-bold mb-4 text-center">
+            <span class="logo-welcome" title="ボクリウム">Bokrium</span><br>
+          </h1>
 
           <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "needs-validation", novalidate: true }) do |f| %>
-            <div class="mb-3">
-              <%= f.label :email, class: "form-label" %>
-              <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control", required: true %>
+            <div class="form-floating mb-3">
+              <%= f.email_field :email,
+                    autofocus: true,
+                    autocomplete: "email",
+                    class: "form-control",
+                    id: "floatingEmail",
+                    placeholder: "メールアドレス",
+                    required: true %>
+              <%= f.label :email, "メールアドレス", for: "floatingEmail" %>
             </div>
 
-            <div class="mb-3">
-              <%= f.label :password, class: "form-label" %>
-              <%= f.password_field :password, autocomplete: "current-password", class: "form-control", required: true %>
+            <div class="form-floating mb-3">
+              <%= f.password_field :password,
+                    autocomplete: "current-password",
+                    class: "form-control",
+                    id: "floatingPassword",
+                    placeholder: "6文字以上のパスワード",
+                    required: true %>
+              <%= f.label :password, "パスワード", for: "floatingPassword" %>
             </div>
-
             <% if devise_mapping.rememberable? %>
-              <div class="form-check mb-3 text-start">
+              <div class="form-check mb-3 text-start text-muted">
                 <%= f.check_box :remember_me, class: "form-check-input", id: "remember_me" %>
                 <%= f.label :remember_me, class: "form-check-label", for: "remember_me" %>
               </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -24,7 +24,7 @@
                     autocomplete: "current-password",
                     class: "form-control",
                     id: "floatingPassword",
-                    placeholder: "6文字以上のパスワード",
+                    placeholder: "パスワード",
                     required: true %>
               <%= f.label :password, "パスワード", for: "floatingPassword" %>
             </div>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,26 +1,32 @@
 <% devise_mapping ||= Devise.mappings[:user] %>
 
-<%- if controller_name != 'sessions' %>
-  <%= link_to t(".sign_in"), new_session_path(resource_name) %><br />
+<% if controller_name != 'sessions' %>
+  <%= link_to t(".sign_in"), new_session_path(resource_name), class: "d-block mb-1 text-decoration-none" %>
 <% end %>
 
-<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to t(".sign_up"), new_registration_path(resource_name) %><br />
+<% if devise_mapping.registerable? && controller_name != 'registrations' %>
+  <%= link_to t(".sign_up"), new_registration_path(resource_name), class: "d-block mb-1 text-decoration-none" %>
 <% end %>
 
-<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to t(".forgot_your_password"), new_password_path(resource_name) %><br />
+<% if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+  <%= link_to t(".forgot_your_password"), new_password_path(resource_name), class: "d-block mb-1 text-decoration-none" %>
 <% end %>
 
-<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to t('.didn_t_receive_confirmation_instructions'), new_confirmation_path(resource_name) %><br />
+<% if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+  <%= link_to t('.didn_t_receive_confirmation_instructions'), new_confirmation_path(resource_name), class: "d-block mb-1 text-decoration-none" %>
 <% end %>
 
-<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to t('.didn_t_receive_unlock_instructions'), new_unlock_path(resource_name) %><br />
+<% if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+  <%= link_to t('.didn_t_receive_unlock_instructions'), new_unlock_path(resource_name), class: "d-block mb-1 text-decoration-none" %>
 <% end %>
 
 <% if devise_mapping.omniauthable? %>
+  <div class="d-flex align-items-center my-4">
+    <hr class="flex-grow-1">
+    <h3 class="mx-3 mb-0 h6 text-muted">または他の方法でログイン</h3>
+    <hr class="flex-grow-1">
+  </div>
+
   <% Devise.omniauth_configs.keys.each do |provider| %>
     <% provider_class = "btn btn-block d-flex align-items-center justify-content-center gap-2 mb-2" %>
 

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -19,7 +19,7 @@ ja:
         password: パスワード
         password_confirmation: パスワード（確認用）
         remember_created_at: ログイン記憶時刻
-        remember_me: ログインを記憶する
+        remember_me: ログイン状態を保持する
         reset_password_sent_at: パスワードリセット送信時刻
         reset_password_token: パスワードリセット用トークン
         sign_in_count: ログイン回数

--- a/spec/system/users/confirmation_spec.rb
+++ b/spec/system/users/confirmation_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe 'User email confirmation', type: :system do
 
   it 'Deviseから送信された確認リンクでメール認証できること' do
     visit new_user_registration_path
-    fill_in 'メールアドレス', with: 'confirmtest@example.com'
-    fill_in 'パスワード', with: 'password123'
-    fill_in 'パスワード（確認用）', with: 'password123'
+    fill_in 'floatingEmail', with: 'confirmtest@example.com'
+    fill_in 'floatingPassword', with: 'password123'
+    fill_in 'floatingPasswordConfirmation', with: 'password123'
     click_button 'アカウント登録'
 
     expect(page).to have_content '確認用のメールを送信しました'

--- a/spec/system/users/confirmation_spec.rb
+++ b/spec/system/users/confirmation_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'User login after confirmation', type: :system do
 
   it 'メール確認済みのユーザーが正常にログインできること' do
     visit new_user_session_path
-    fill_in 'Eメール', with: email
+    fill_in 'メールアドレス', with: email
     fill_in 'パスワード', with: password
     click_button 'ログイン'
 

--- a/spec/system/users/confirmation_spec.rb
+++ b/spec/system/users/confirmation_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'User email confirmation', type: :system do
 
   it 'Deviseから送信された確認リンクでメール認証できること' do
     visit new_user_registration_path
-    fill_in 'Eメール', with: 'confirmtest@example.com'
+    fill_in 'メールアドレス', with: 'confirmtest@example.com'
     fill_in 'パスワード', with: 'password123'
     fill_in 'パスワード（確認用）', with: 'password123'
     click_button 'アカウント登録'


### PR DESCRIPTION
# ログイン・新規登録フォームのUI改善

## 変更点

- form-floating を導入
- 入力前は placeholder のみ表示
- 入力時／フォーカス時にラベルがフォーム外にふわっと表示されるよう調整
- リンクの下線を非表示に
- 「ログインを記憶する」→「ログイン状態を保持する」