### PR TITLE
UI/detail card cover

### DIFF
--- a/app/assets/stylesheets/_detail_card.scss
+++ b/app/assets/stylesheets/_detail_card.scss
@@ -1,5 +1,5 @@
 
-.detail-src { width: 100px; height: auto; object-fit: cover; }
+.detail-src { width: 100px !important; height: auto; object-fit: cover; }
 
 .detail-nocover { max-width: 100px;}
 

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -87,9 +87,9 @@ class BooksController < ApplicationController
     @book = current_user.books.build(book_params)
 
     if @book.save
-      respond_success("本棚に『#{@book.title.truncate(TITLE_TRUNCATE_LIMIT)}』を追加しました")
+      respond_success("本棚に『#{@book.title.truncate(TITLE_TRUNCATE_LIMIT)}』を追加しました。")
     else
-      respond_failure(@book.errors.full_messages.to_sentence.presence || "追加に失敗しました")
+      respond_failure(@book.errors.full_messages.to_sentence.presence || "追加に失敗しました。")
     end
   end
 
@@ -121,7 +121,7 @@ class BooksController < ApplicationController
       redirect_to @book
     else
       error_messages = @book.errors.full_messages.join("、")
-      flash.now[:danger] = "画像の保存に失敗しました。：#{error_messages}"
+      flash.now[:danger] = "画像の保存に失敗しました：#{error_messages}"
       render :edit
     end
   end

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -16,6 +16,7 @@ class BooksController < ApplicationController
           .includes(book_cover_s3_attachment: :blob)
           .order(created_at: :desc)
           .to_a
+        @read_only = true
       end
       return
     end
@@ -88,13 +89,7 @@ class BooksController < ApplicationController
     if @book.save
       respond_success("本棚に『#{@book.title.truncate(TITLE_TRUNCATE_LIMIT)}』を追加しました")
     else
-      error_msg = @book.errors.full_messages.to_sentence
-
-      if @book.errors.details[:base].any? { |e| e[:error] == :limit_exceeded }
-        render turbo_stream: limit_error_stream(id: "book_limit_error", message: error_msg)
-      else
-        respond_failure(@book.errors.full_messages.to_sentence.presence || "追加に失敗しました")
-      end
+      respond_failure(@book.errors.full_messages.to_sentence.presence || "追加に失敗しました")
     end
   end
 
@@ -122,11 +117,11 @@ class BooksController < ApplicationController
 
   def update
     if @book.update(book_params)
-      flash[:info] = "『#{@book.title.truncate(TITLE_TRUNCATE_LIMIT)}』を更新しました"
+      flash[:info] = "『#{@book.title.truncate(TITLE_TRUNCATE_LIMIT)}』を更新しました。"
       redirect_to @book
     else
       error_messages = @book.errors.full_messages.join("、")
-      flash.now[:danger] = "画像の保存に失敗しました：#{error_messages}"
+      flash.now[:danger] = "画像の保存に失敗しました。：#{error_messages}"
       render :edit
     end
   end
@@ -136,7 +131,7 @@ class BooksController < ApplicationController
     index = params[:index].to_i
 
     if @book.update(book_params)
-      flash.now[:row_update_success] = "『#{@book.title.truncate(20)}』を更新しました"
+      flash.now[:row_update_success] = "『#{@book.title.truncate(20)}』を更新しました。"
       render partial: "bookshelf/b_note_row", formats: :html, locals: { book: @book, index: index }
     else
       render partial: "bookshelf/b_note_edit_row", formats: :html, locals: { book: @book, index: index }
@@ -144,7 +139,7 @@ class BooksController < ApplicationController
   end
   def destroy
     @book.destroy
-    flash[:info] = "『#{@book.title.truncate(TITLE_TRUNCATE_LIMIT)}』を削除しました"
+    flash[:info] = "『#{@book.title.truncate(TITLE_TRUNCATE_LIMIT)}』を削除しました。"
 
     if params[:force_html]
       redirect_to books_path, notice: flash[:info]

--- a/app/controllers/guest/books_controller.rb
+++ b/app/controllers/guest/books_controller.rb
@@ -52,7 +52,7 @@ module Guest
     end
 
     def handle_guest_not_found
-      flash[:danger] = "この本はゲスト表示できません"
+      flash[:danger] = "この本はゲスト表示できません。"
       redirect_to root_path
     end
   end

--- a/app/controllers/guest/starter_books_controller.rb
+++ b/app/controllers/guest/starter_books_controller.rb
@@ -55,7 +55,7 @@ module Guest
     end
 
     def handle_guest_not_found
-      flash[:danger] = "この本はゲスト表示できません"
+      flash[:danger] = "この本はゲスト表示できません。"
       redirect_to root_path
     end
   end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -10,14 +10,8 @@ class ImagesController < ApplicationController
         format.html { redirect_to @book }
       end
     else
-        error_msg = @image.errors.full_messages.to_sentence
-
-      if @image.errors.details[:base].any? { |e| e[:error] == :limit_exceeded }
-        render turbo_stream: limit_error_stream(id: "image_limit_error", message: error_msg)
-      else
-        flash[:danger] = "画像の保存に失敗しました：#{error_msg}"
-        redirect_to @book
-      end
+      flash[:danger] = "画像の保存に失敗しました：#{@image.errors.full_messages.to_sentence}"
+      redirect_to @book
     end
   end
 

--- a/app/controllers/line_sessions_controller.rb
+++ b/app/controllers/line_sessions_controller.rb
@@ -16,7 +16,7 @@ class LineSessionsController < ApplicationController
       flash[:info] = "LINE連携が完了しました！"
       redirect_to mypage_path(current_user)
     else
-      flash[:danger] = "ログインしてからLINE連携してください"
+      flash[:danger] = "ログインしてからLINE連携してください。"
       redirect_to root_path
     end
   end

--- a/app/controllers/memos_controller.rb
+++ b/app/controllers/memos_controller.rb
@@ -16,19 +16,13 @@ class MemosController < ApplicationController
     @memo = current_user.memos.new(memo_params)
     @memo.book_id = params[:book_id]
     @book = @memo.book
-    # @memos = @book.memos.order(created_at: :asc)
 
     if @memo.save
-      flash[:info] = "メモを保存しました"
+      flash[:info] = "メモを保存しました。"
       redirect_to book_path(@memo.book)
     else
-      error_msg = @memo.errors.full_messages.to_sentence
-      if @memo.errors.details[:base].any? { |e| e[:error] == :limit_exceeded }
-        render turbo_stream: limit_error_stream(id: "memo_limit_error", message: error_msg)
-      else
-        flash[:danger] = "メモの保存に失敗しました"
-        render "books/show", status: :unprocessable_entity
-      end
+      flash[:danger] = "メモの保存に失敗しました。"
+      render "books/show", status: :unprocessable_entity
     end
   end
 
@@ -39,17 +33,17 @@ class MemosController < ApplicationController
     @memos = @book.memos.order(created_at: :asc)
     @memo = Memo.find(params[:id])
     if @memo.update(memo_params)
-      flash[:info] = "メモを保存しました"
+      flash[:info] = "メモを保存しました。"
       redirect_to book_path(@memo.book)
     else
-      flash[:danger] = "メモの保存に失敗しました"
+      flash[:danger] = "メモの保存に失敗しました。"
       render status: :unprocessable_entity
     end
   end
 
   def destroy
     @memo.destroy
-    flash.now[:info] = "メモを削除しました"
+    flash.now[:info] = "メモを削除しました。"
     respond_to do |format|
       format.turbo_stream do
         render turbo_stream: [
@@ -70,7 +64,7 @@ class MemosController < ApplicationController
   def set_memo
     @memo = Memo.find(params[:id])
     unless @memo.user_id == current_user.id || @memo.shared?
-      flash[:danger] = "アクセス権限がありません"
+      flash[:danger] = "アクセス権限がありません。"
       redirect_to book_memo_path(@book)
     end
   end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -47,7 +47,7 @@ class SearchController < ApplicationController
   def search_google_books
     query = params[:query]
     page = (params[:page] || 1).to_i
-    return redirect_to search_books_path, alert: "検索キーワードがありません" if query.blank?
+    return redirect_to search_books_path, alert: "検索キーワードがありません。" if query.blank?
     @query = query
     @page = page
 
@@ -56,11 +56,11 @@ class SearchController < ApplicationController
 
     if @google_book_results.blank?
       if page == 1
-        flash.now[:warning] = "Google Booksで該当する書籍が見つかりませんでした（#{query}）"
+        flash.now[:warning] = "Google Booksで該当する書籍が見つかりませんでした：（#{query}）"
         @google_total_count = 0
         @google_total_pages = 0
       else
-        flash.now[:warning] = "Google Booksでこれ以上の結果が見つかりませんでした（#{query}）"
+        flash.now[:warning] = "Google Booksでこれ以上の結果が見つかりませんでした：（#{query}）"
         @google_total_count = (page - 1) * 30
         @google_total_pages = page - 1
       end
@@ -94,14 +94,14 @@ class SearchController < ApplicationController
         render turbo_stream: turbo_stream.prepend(
           "scanned-books",
           partial: "search/isbn_flash",
-          locals: { message: "#{isbn} の書籍が見つかりません" }
+          locals: { message: "#{isbn} の書籍が見つかりません。" }
         )
       end
     rescue => e
       Rails.logger.error(e)
       render turbo_stream: turbo_stream.prepend(
         "scanned-books",
-        html: "システムエラーが発生しました"
+        html: "システムエラーが発生しました。"
       )
     end
   end
@@ -122,7 +122,7 @@ class SearchController < ApplicationController
       @rakuten_total_pages = (@rakuten_total_count / 30.0).ceil
 
       if books.blank?
-        flash.now[:warning] = "楽天ブックスで該当する書籍が見つかりませんでした（#{query}）"
+        flash.now[:warning] = "楽天ブックスで該当する書籍が見つかりませんでした：（#{query}）"
       end
     rescue RakutenWebService::Error => e
       flash[:error] = "楽天APIでエラーが発生しました: #{e.message}"

--- a/app/controllers/user_tags_controller.rb
+++ b/app/controllers/user_tags_controller.rb
@@ -6,7 +6,7 @@ class UserTagsController < ApplicationController
     @user_tag.color = user_tag_params[:color] if user_tag_params[:color].present?
 
     if @user_tag.save
-      flash[:info] = "タグ「#{@user_tag.name}」を作成しました"
+      flash[:info] = "タグ「#{@user_tag.name}」を作成しました。"
     else
       flash[:danger] = "タグの作成に失敗しました: " + @user_tag.errors.full_messages.join(", ")
     end
@@ -15,7 +15,7 @@ class UserTagsController < ApplicationController
 
   def update
     if @user_tag.update(user_tag_params)
-      flash[:info] = "タグ「#{@user_tag.name}」を更新しました"
+      flash[:info] = "タグ「#{@user_tag.name}」を更新しました。"
     else
       flash[:danger] = "タグの更新に失敗しました: " + @user_tag.errors.full_messages.join(", ")
     end
@@ -28,7 +28,7 @@ class UserTagsController < ApplicationController
   def destroy
     tag_name = @user_tag.name
     @user_tag.destroy
-    flash[:info] = "タグ「#{tag_name}」を削除しました"
+    flash[:info] = "タグ「#{tag_name}」を削除しました。"
     redirect_back fallback_location: root_path
   end
 

--- a/app/controllers/webhooks/email_notifications_controller.rb
+++ b/app/controllers/webhooks/email_notifications_controller.rb
@@ -4,7 +4,7 @@ class Webhooks::EmailNotificationsController < ApplicationController
 
   def create
     EmailNotificationSender.send_all
-    render json: { status: "ok", message: "通知を送信しました" }, status: :ok
+    render json: { status: "ok", message: "通知を送信しました。" }, status: :ok
   rescue => e
     Rails.logger.error("メール通知のWebhook失敗: #{e.class} - #{e.message}")
     render json: { status: "error", message: e.message }, status: :internal_server_error
@@ -15,7 +15,7 @@ class Webhooks::EmailNotificationsController < ApplicationController
   def verify_cron_token!
     token = request.headers["X-EMAIL-CRON-TOKEN"]
     unless ActiveSupport::SecurityUtils.secure_compare(token.to_s, ENV["EMAIL_CRON_TOKEN"].to_s)
-      render json: { status: "unauthorized", message: "無効なトークンです" }, status: :unauthorized
+      render json: { status: "unauthorized", message: "無効なトークンです。" }, status: :unauthorized
     end
   end
 end

--- a/app/helpers/books_helper.rb
+++ b/app/helpers/books_helper.rb
@@ -31,7 +31,7 @@ module BooksHelper
   end
 
 
-  def display_book_cover(book, resize_to: [ 200 ], alt: nil,
+  def display_book_cover(book, alt: nil,
                         s3_class: "", url_class: "", no_cover_class: "", no_cover_title: nil,
                         nocover_img: false, truncate_options: {}, **options)
     return unless book.present?
@@ -43,7 +43,6 @@ module BooksHelper
         alt: alt,
         loading: "lazy",
         class: "img-fluid #{s3_class}".strip,
-        width: resize_to[0],
         height: "auto"
       }.merge(options)
 

--- a/app/views/bookshelf/_detail_card.html.erb
+++ b/app/views/bookshelf/_detail_card.html.erb
@@ -40,7 +40,6 @@ end %>
           <div class="row g-3">
             <div class="col-auto">
               <%= display_book_cover book,
-                  resize_to: [100],
                   s3_class: "book-cover rounded-2 detail-src",
                   url_class: "rounded-2 detail-src",
                   no_cover_class: "detail-nocover",

--- a/db/migrate/20250702043558_remove_text_index_trigger_from_memos.rb
+++ b/db/migrate/20250702043558_remove_text_index_trigger_from_memos.rb
@@ -1,0 +1,8 @@
+class RemoveTextIndexTriggerFromMemos < ActiveRecord::Migration[8.0]
+  def change
+    execute <<~SQL
+      DROP TRIGGER IF EXISTS update_text_index ON memos;
+      DROP FUNCTION IF EXISTS memos_text_index_trigger();
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_26_145558) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_02_043558) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"


### PR DESCRIPTION
## Update: 書影サイズとフラッシュメッセージ、不要な処理の整理

- 詳細ビューのS3書影の表示サイズを調整  
- フラッシュメッセージの語尾に句点（「。」）を追加し、トーンを統一  
- 不要となった `limit_exceeded` 関連のバリデーション・エラーハンドリングを削除