### PR TITLE
Responsive/flash messgaes

### DIFF
--- a/app/assets/stylesheets/_flash.scss
+++ b/app/assets/stylesheets/_flash.scss
@@ -7,8 +7,8 @@
   display: inline-flex;
   align-items: center;
   gap: 0.75rem;
-  min-width: 9vw;
   max-width: 90vw;
+  width: max-content;
   padding: 0.75rem 1.25rem;
   font-size: 1rem;
   font-weight: 500;
@@ -17,6 +17,7 @@
   border-radius: 0.75rem;
   animation: appear-then-fade 5s both;
   opacity: 0;
+  box-sizing: border-box;
 }
 
 .flash-message[data-status="success"] {
@@ -25,6 +26,18 @@
 
 .flash-message[data-status="error"] {
   background-color: #e34c4c;
+}
+
+.flash-message .flash-message-text {
+  display: inline-block;
+  white-space: normal;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  min-width: 0;
+}
+
+.flash-message i {
+  flex-shrink: 0;
 }
 
 @keyframes appear-then-fade {

--- a/app/helpers/books_helper.rb
+++ b/app/helpers/books_helper.rb
@@ -52,10 +52,10 @@ module BooksHelper
                   style: "" }.merge(options)
 
     elsif nocover_img
-      content_tag(:div, class: "cover-placeholder-wrapper") do
+      content_tag(:div, class: "cover-placeholder-wrapper #{no_cover_class}") do
         image_tag("no_cover.png", class: "img-fluid rounded-sm placeholder-cover") +
           content_tag(:div, truncate_for_device(book.title, **truncate_options),
-                      class: "cover-title-overlay brake-word #{no_cover_class}") +
+                      class: "cover-title-overlay brake-word") +
           content_tag(:div, "Bokrium", class: "logo-overlay")
       end
     else

--- a/app/views/bookshelf/_detail_card.html.erb
+++ b/app/views/bookshelf/_detail_card.html.erb
@@ -42,8 +42,8 @@ end %>
               <%= display_book_cover book,
                   s3_class: "book-cover rounded-2 detail-src",
                   url_class: "rounded-2 detail-src",
-                  no_cover_class: "detail-nocover",
-                  no_cover_title: "small text-center px-1"
+                  nocover_img: true,
+                  no_cover_class: "detail-nocover"
               %>
             </div>
             <div class="col d-flex flex-column gap-1" style="word-break: break-all;">
@@ -57,5 +57,7 @@ end %>
     </div>
   <% end %>
 </div>
+
+
 
 <%= render "shared/pagy", pagy: pagy %>

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,18 +1,18 @@
 <% flash.each do |type, message| %>
   <% icon = case type.to_sym
     when :success, :notice, :info then "bi bi-patch-check-fill"
-    when :alert, :error, :danger then "bi bi-exclamation-triangle-fill"
-    else "bi bi-patch-check-fill text-info"
+    when :alert, :error, :danger  then "bi bi-exclamation-triangle-fill"
+    else "bi bi-info-circle-fill"
   end %>
 
   <% status = case type.to_sym
     when :success, :notice, :info then "success"
-    when :alert, :error, :danger then "error"
+    when :alert, :error, :danger  then "error"
     else "info"
   end %>
 
-  <div class="flash-message d-flex align-items-center gap-2 shadow" data-status="<%= status %>">
-    <i class="<%= icon %>" style="font-size: 1.25rem;"></i>
-    <div><%= message %></div>
+  <div class="flash-message shadow" data-status="<%= status %>">
+    <i class="<%= icon %>"></i>
+    <span class="flash-message-text"><%= message %></span>
   </div>
 <% end %>


### PR DESCRIPTION
## フラッシュメッセージの幅調整＆nocover画像の表示サイズを統一

- フラッシュメッセージが内容に応じて最大90vwまで広がるように修正
- nocover 書影のみサイズが他とズレていた問題を修正（共通クラス適用）
- 見た目の統一感を保ちつつ、アニメーションや背景色の仕様は維持