### PR TITLE
Feat: production環境にて Viteアセットを Cloudflare R2 経由で配信するための asset_host を設定

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,7 +22,7 @@ Rails.application.configure do
   config.public_file_server.headers = { "cache-control" => "public, max-age=#{1.year.to_i}" }
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.asset_host = "https://assets.bokrium.com"
+  config.asset_host = "https://assets.bokrium.com"
 
   # Store uploaded files in Tigris Global Object Storage (see config/storage.yml for options).
   config.active_storage.service = :cloudflare_private_r2


### PR DESCRIPTION
## 📦 本番環境でのCDN配信テスト用の asset_host 設定を追加

本番環境で Vite によるビルド済みアセットを Cloudflare R2 経由で配信するために、以下の設定を追加しました。

✅ 主な変更点
- config/environments/production.rb に config.asset_host を追加
↳ Rails側の vite_javascript_tag などがCDN URLで出力されるようにするため
