### PR TITLE
Fix: bokrium.fly.dev へのアクセスを bokrium.com にリダイレクト

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -2,6 +2,11 @@ require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
+  config.middleware.insert_before(0, Rack::Rewrite) do
+    r301 %r{.*}, 'https://bokrium.com$&', if: Proc.new { |rack_env|
+      rack_env['HTTP_HOST'] == 'bokrium.fly.dev'
+    }
+  end
 
   # Code is not reloaded between requests.
   config.enable_reloading = false


### PR DESCRIPTION
## 概要
`.fly.dev` ドメインへのアクセスを、SEOやセキュリティ対策のために `https://bokrium.com` へ 301 リダイレクトするよう対応しました。

## 対応内容
- `rack-rewrite` を使用して、 `production.rb` にてリダイレクトルールを設定

## 補足
- リダイレクトは `HTTP_HOST` が `bokrium.fly.dev` のときのみ発動します。
- 恒久的リダイレクト（301）なので、SEO上も安心です。