### PR TITLE
Infra: Cloudflare R2へのViteアセットアップロード時にCache-Controlを付与

### DIFF
--- a/.github/workflows/upload-vite-assets-to-r2.yml
+++ b/.github/workflows/upload-vite-assets-to-r2.yml
@@ -31,5 +31,6 @@ jobs:
         run: |
           aws s3 sync public/vite s3://${{ secrets.R2_BUCKET }}/vite \
             --endpoint-url=${{ secrets.R2_ENDPOINT }} \
+            --cache-control "public, max-age=31536000, immutable" \
             --delete \
-          --acl public-read
+            --acl public-read


### PR DESCRIPTION
## 概要
Lighthouseで「キャッシュ保存期間が短すぎます」という警告が出ていたため、Cloudflare R2にアップロードされる Vite アセットに `Cache-Control` ヘッダーを追加しました。

## 対応内容
- GitHub Actionsの `aws s3 sync` コマンドに以下のオプションを追加：
`–cache-control “public, max-age=31536000, immutable”`

- これにより、R2 → ブラウザ間のキャッシュが1年有効になり、再検証も不要になります。

## 期待される効果
- Lighthouseのスコア向上
- 表示速度の改善
- Cloudflare の `cf-cache-status` が HIT になりやすくなる

ご確認よろしくお願いします！