### PR TITLE
fix: preserve WebAuthn user activation context

### DIFF
--- a/app/controllers/users/credentials_controller.rb
+++ b/app/controllers/users/credentials_controller.rb
@@ -6,19 +6,13 @@ module Users
 
     # 登録開始（challenge 生成）
     def new
-      # 既存のパスキーを除外リストに追加
-      exclude_credentials = current_user.credentials.map do |cred|
-        Base64.strict_decode64(cred.external_id)
-      end
-
-      # WebAuthn の登録オプションを生成
       options = WebAuthn::Credential.options_for_create(
         user: {
           id: current_user.id.to_s,
           name: current_user.email,
           display_name: current_user.name || current_user.email
         },
-        exclude: exclude_credentials,
+        exclude: current_user.credentials.pluck(:external_id),
         authenticator_selection: {
           # authenticator_attachment を指定しない（platform と cross-platform 両方を許可）
           require_resident_key: false,
@@ -26,94 +20,26 @@ module Users
         }
       )
 
-      # challenge をセッションに保存（URLセーフBase64、パディングなしで保存）
-      challenge_b64 = Base64.urlsafe_encode64(options.challenge, padding: false)
-      session[:webauthn_challenge] = challenge_b64
+      session[:webauthn_creation_challenge] = options.challenge
 
-      # フロントエンドに JSON で返す
-      render json: {
-        challenge: challenge_b64,
-        rp: {
-          name: options.rp.name,
-          id: options.rp.id
-        },
-        user: {
-          id: Base64.strict_encode64(options.user.id),
-          name: options.user.name,
-          displayName: options.user.display_name
-        },
-        pubKeyCredParams: options.pub_key_cred_params,
-        timeout: options.timeout,
-        excludeCredentials: exclude_credentials.map { |cred_id|
-          {
-            type: "public-key",
-            id: Base64.strict_encode64(cred_id)
-          }
-        },
-        authenticatorSelection: options.authenticator_selection,
-        attestation: options.attestation
-      }
+      render json: options
     end
 
     # 登録完了（credential 保存）
     def create
-      # セッションから challenge を取得
-      stored_challenge_b64 = session[:webauthn_challenge]
+      stored_challenge = session[:webauthn_creation_challenge]
 
-      unless stored_challenge_b64
+      unless stored_challenge
         render json: { error: "登録セッションが無効です。再度お試しください。" }, status: :bad_request
         return
       end
 
-      # URLセーフBase64デコードしてバイナリに戻す
-      stored_challenge = Base64.urlsafe_decode64(stored_challenge_b64)
-
-      # デバッグログ
-      Rails.logger.debug("=== WebAuthn verification ===")
-      Rails.logger.debug("Stored challenge (hex): #{stored_challenge.unpack1('H*')}")
-      Rails.logger.debug("Stored challenge (base64): #{stored_challenge_b64}")
-      Rails.logger.debug("Stored challenge class: #{stored_challenge.class}")
-      Rails.logger.debug("Stored challenge encoding: #{stored_challenge.encoding}")
-
-      # WebAuthn検証（webauthn gemがclientDataJSONから challengeを抽出して検証）
       webauthn_credential = WebAuthn::Credential.from_create(params)
 
-      # clientDataJSON から challenge を取得して比較
-      client_data_json_binary = Base64.urlsafe_decode64(params[:response][:clientDataJSON])
-      client_data_hash = JSON.parse(client_data_json_binary)
-      client_challenge_b64 = client_data_hash["challenge"]
-      client_challenge_binary = Base64.urlsafe_decode64(client_challenge_b64)
-
-      Rails.logger.debug("=== Challenge binary comparison ===")
-      Rails.logger.debug("Client challenge (hex): #{client_challenge_binary.unpack1('H*')}")
-      Rails.logger.debug("Client challenge class: #{client_challenge_binary.class}")
-      Rails.logger.debug("Client challenge encoding: #{client_challenge_binary.encoding}")
-      Rails.logger.debug("Binary match?: #{stored_challenge == client_challenge_binary}")
-      Rails.logger.debug("Byte-by-byte match?: #{stored_challenge.bytes == client_challenge_binary.bytes}")
-
       begin
-        # 検証実行
-        # verify() は内部で encoder.decode(challenge) を呼ぶので、
-        # challenge は base64 エンコードされた文字列を渡す必要がある
-        webauthn_credential.verify(stored_challenge_b64)
-        Rails.logger.debug("WebAuthn verification successful!")
-      rescue WebAuthn::ChallengeVerificationError => e
-        Rails.logger.error("Challenge verification failed!")
-        Rails.logger.error("Error: #{e.inspect}")
-
-        # clientDataJSON をデコードして詳細を確認
-        client_data_json = Base64.urlsafe_decode64(params[:response][:clientDataJSON])
-        client_data = JSON.parse(client_data_json)
-        Rails.logger.error("Client challenge (from clientDataJSON): #{client_data['challenge']}")
-        Rails.logger.error("Stored challenge (base64): #{stored_challenge_b64}")
-        Rails.logger.error("Match?: #{client_data['challenge'] == stored_challenge_b64}")
-
-        render json: { error: "登録に失敗しました。再度お試しください。" }, status: :unprocessable_entity
-        return
+        webauthn_credential.verify(stored_challenge)
       rescue WebAuthn::Error => e
         Rails.logger.error("WebAuthn 登録失敗: #{e.class} - #{e.message}")
-        Rails.logger.error("Full error: #{e.inspect}")
-        Rails.logger.error("Backtrace: #{e.backtrace.first(10).join("\n")}")
         render json: { error: "登録に失敗しました。再度お試しください。" }, status: :unprocessable_entity
         return
       end
@@ -126,8 +52,7 @@ module Users
       )
 
       if credential.save
-        # セッションから challenge を削除
-        session.delete(:webauthn_challenge)
+        session.delete(:webauthn_creation_challenge)
 
         # パスキー登録完了後、スターターガイドへリダイレクト
         render json: {

--- a/app/controllers/users/webauthn_sessions_controller.rb
+++ b/app/controllers/users/webauthn_sessions_controller.rb
@@ -4,40 +4,27 @@ module Users
   class WebauthnSessionsController < ApplicationController
     # ログイン開始（challenge 生成）
     def new
-      # WebAuthn の認証オプションを生成
       options = WebAuthn::Credential.options_for_get(
         allow: [],
         user_verification: "preferred"
       )
 
-      # challenge を URLsafe Base64 (padding なし) でエンコードしてセッションに保存
-      challenge_b64 = Base64.urlsafe_encode64(options.challenge, padding: false)
-      session[:webauthn_challenge] = challenge_b64
+      session[:webauthn_authentication_challenge] = options.challenge
 
-      # フロントエンドに JSON で返す（同じ形式で）
-      render json: {
-        challenge: challenge_b64,
-        timeout: options.timeout,
-        rpId: WebAuthn.configuration.rp_id,
-        allowCredentials: [],
-        userVerification: "preferred"
-      }
+      render json: options
     end
 
     # ログイン完了（署名検証）
     def create
       webauthn_credential = WebAuthn::Credential.from_get(params)
 
-      # セッションから challenge を取得
-      stored_challenge = session[:webauthn_challenge]
+      stored_challenge = session[:webauthn_authentication_challenge]
 
-      # challenge が存在しない場合
       unless stored_challenge
         render json: { error: "認証セッションが無効です。再度お試しください。" }, status: :bad_request
         return
       end
 
-      # credential を DB から検索
       credential = Credential.find_by(external_id: Base64.strict_encode64(webauthn_credential.raw_id))
 
       unless credential
@@ -45,9 +32,6 @@ module Users
         return
       end
 
-      # 署名を検証
-      # verify() は内部で encoder.decode(challenge) を呼ぶので、
-      # challenge は base64 エンコードされた文字列を渡す必要がある
       begin
         webauthn_credential.verify(
           stored_challenge,
@@ -60,17 +44,13 @@ module Users
         return
       end
 
-      # sign_count を更新（replay attack 対策）
       credential.update!(sign_count: webauthn_credential.sign_count)
 
-      # セッションから challenge を削除
-      session.delete(:webauthn_challenge)
+      session.delete(:webauthn_authentication_challenge)
 
-      # ユーザーをログイン
       user = credential.user
       sign_in(user)
 
-      # レスポンス
       render json: { success: true, redirect_to: after_sign_in_path_for(user) }
     end
 

--- a/app/frontend/entrypoints/controllers/webauthn_login_controller.ts
+++ b/app/frontend/entrypoints/controllers/webauthn_login_controller.ts
@@ -1,32 +1,54 @@
 import { Controller } from "@hotwired/stimulus";
 
+type LoginOptionsResponse = {
+  challenge: string;
+  timeout?: number;
+  rpId?: string;
+  allowCredentials: Array<{
+    id: string;
+    type: string;
+    transports?: AuthenticatorTransport[];
+  }>;
+  userVerification?: UserVerificationRequirement;
+};
+
 export default class WebauthnLoginController extends Controller<HTMLElement> {
+  private preparedOptions: LoginOptionsResponse | null = null;
+  private optionsRequest: Promise<LoginOptionsResponse> | null = null;
+
+  connect(): void {
+    // Safari / WebKit では click 内の非同期 fetch 後に get() を呼ぶと
+    // user gesture を失って失敗しやすいため、先に options を取っておく。
+    void this.prepare();
+  }
+
+  async prepare(): Promise<void> {
+    try {
+      await this.loadOptions();
+    } catch (error) {
+      console.warn("WebAuthn 認証オプションの事前取得に失敗:", error);
+    }
+  }
+
   async login(): Promise<void> {
     try {
-      // 1. サーバーから challenge を取得
-      const optionsResponse = await fetch("/users/webauthn_login", {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-        },
-      });
+      const options = await this.loadOptions();
 
-      if (!optionsResponse.ok) {
-        throw new Error("認証オプションの取得に失敗しました。");
-      }
-
-      const options = await optionsResponse.json();
-
-      // 2. Base64 デコード
+      // 1. Base64 デコード
       const challenge = this.base64ToArrayBuffer(options.challenge);
+      const allowCredentials = options.allowCredentials.map((credential) => ({
+        ...credential,
+        type: credential.type as PublicKeyCredentialType,
+        id: this.base64ToArrayBuffer(credential.id),
+      }));
 
-      // 3. WebAuthn API を呼び出し
+      // 2. WebAuthn API を呼び出し
       const credential = (await navigator.credentials.get({
         publicKey: {
           challenge,
           timeout: options.timeout,
           rpId: options.rpId,
-          allowCredentials: options.allowCredentials,
+          allowCredentials,
           userVerification: options.userVerification || "preferred",
         },
       })) as PublicKeyCredential | null;
@@ -36,7 +58,7 @@ export default class WebauthnLoginController extends Controller<HTMLElement> {
         return;
       }
 
-      // 4. レスポンスを整形
+      // 3. レスポンスを整形
       const response = credential.response as AuthenticatorAssertionResponse;
       const body = {
         id: credential.id,
@@ -52,7 +74,7 @@ export default class WebauthnLoginController extends Controller<HTMLElement> {
         },
       };
 
-      // 5. サーバーに送信して検証
+      // 4. サーバーに送信して検証
       const verifyResponse = await fetch("/users/webauthn_login", {
         method: "POST",
         headers: {
@@ -61,6 +83,8 @@ export default class WebauthnLoginController extends Controller<HTMLElement> {
         },
         body: JSON.stringify(body),
       });
+
+      this.preparedOptions = null;
 
       if (!verifyResponse.ok) {
         const errorData = await verifyResponse.json();
@@ -77,9 +101,44 @@ export default class WebauthnLoginController extends Controller<HTMLElement> {
         alert("ログインに失敗しました。");
       }
     } catch (error) {
+      this.preparedOptions = null;
       console.error("WebAuthn ログインエラー:", error);
       alert("エラーが発生しました。再度お試しください。");
     }
+  }
+
+  private async loadOptions(): Promise<LoginOptionsResponse> {
+    if (this.preparedOptions) {
+      return this.preparedOptions;
+    }
+
+    if (this.optionsRequest) {
+      return this.optionsRequest;
+    }
+
+    this.optionsRequest = fetch("/users/webauthn_login", {
+      method: "GET",
+      cache: "no-store",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    })
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error("認証オプションの取得に失敗しました。");
+        }
+
+        return (await response.json()) as LoginOptionsResponse;
+      })
+      .then((options) => {
+        this.preparedOptions = options;
+        return options;
+      })
+      .finally(() => {
+        this.optionsRequest = null;
+      });
+
+    return this.optionsRequest;
   }
 
   // Helper: Base64 → ArrayBuffer

--- a/app/frontend/entrypoints/controllers/webauthn_registration_controller.ts
+++ b/app/frontend/entrypoints/controllers/webauthn_registration_controller.ts
@@ -50,7 +50,7 @@ export default class WebauthnRegistrationController extends Controller<HTMLEleme
 
       // 1. Base64 デコード
       const challenge = this.base64ToArrayBuffer(options.challenge);
-      const userId = this.base64ToArrayBuffer(options.user.id);
+      const userId = this.textToArrayBuffer(options.user.id);
       const excludeCredentials = options.excludeCredentials.map(
         (cred: { type: string; id: string }) => ({
           type: cred.type as PublicKeyCredentialType,
@@ -169,6 +169,10 @@ export default class WebauthnRegistrationController extends Controller<HTMLEleme
       });
 
     return this.optionsRequest;
+  }
+
+  private textToArrayBuffer(value: string): ArrayBuffer {
+    return new TextEncoder().encode(value).buffer;
   }
 
   // Helper: Base64 → ArrayBuffer

--- a/app/frontend/entrypoints/controllers/webauthn_registration_controller.ts
+++ b/app/frontend/entrypoints/controllers/webauthn_registration_controller.ts
@@ -1,29 +1,54 @@
 import { Controller } from "@hotwired/stimulus";
 
+type RegistrationOptionsResponse = {
+  challenge: string;
+  rp: {
+    name: string;
+    id: string;
+  };
+  user: {
+    id: string;
+    name: string;
+    displayName: string;
+  };
+  pubKeyCredParams: PublicKeyCredentialParameters[];
+  timeout?: number;
+  excludeCredentials: Array<{
+    type: string;
+    id: string;
+  }>;
+  authenticatorSelection?: AuthenticatorSelectionCriteria;
+  attestation?: AttestationConveyancePreference;
+};
+
 export default class WebauthnRegistrationController extends Controller<HTMLElement> {
   static values = {
     redirectUrl: String,
   };
 
   declare redirectUrlValue: string;
+  private preparedOptions: RegistrationOptionsResponse | null = null;
+  private optionsRequest: Promise<RegistrationOptionsResponse> | null = null;
+
+  connect(): void {
+    // WebKit 系は click 内で fetch を挟むと user gesture を失いやすいため、
+    // 先に登録オプションを取得しておく。
+    void this.prepare();
+  }
+
+  async prepare(): Promise<void> {
+    try {
+      await this.loadOptions();
+    } catch (error) {
+      console.warn("WebAuthn 登録オプションの事前取得に失敗:", error);
+    }
+  }
 
   async register(): Promise<void> {
     try {
-      // 1. サーバーから challenge を取得
-      const optionsResponse = await fetch("/users/credentials/new", {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-        },
-      });
+      const options = await this.loadOptions();
 
-      if (!optionsResponse.ok) {
-        throw new Error("登録オプションの取得に失敗しました。");
-      }
-
-      const options = await optionsResponse.json();
-
-      // 2. Base64 デコード
+      // 1. Base64 デコード
       const challenge = this.base64ToArrayBuffer(options.challenge);
       const userId = this.base64ToArrayBuffer(options.user.id);
       const excludeCredentials = options.excludeCredentials.map(
@@ -33,7 +58,7 @@ export default class WebauthnRegistrationController extends Controller<HTMLEleme
         })
       );
 
-      // 3. WebAuthn API を呼び出し
+      // 2. WebAuthn API を呼び出し
       const credential = (await navigator.credentials.create({
         publicKey: {
           challenge,
@@ -59,7 +84,7 @@ export default class WebauthnRegistrationController extends Controller<HTMLEleme
         return;
       }
 
-      // 4. レスポンスを整形
+      // 3. レスポンスを整形
       const response = credential.response as AuthenticatorAttestationResponse;
       const body = {
         id: credential.id,
@@ -71,7 +96,7 @@ export default class WebauthnRegistrationController extends Controller<HTMLEleme
         },
       };
 
-      // 5. サーバーに送信して検証
+      // 4. サーバーに送信して検証
       const verifyResponse = await fetch("/users/credentials", {
         method: "POST",
         headers: {
@@ -80,6 +105,8 @@ export default class WebauthnRegistrationController extends Controller<HTMLEleme
         },
         body: JSON.stringify(body),
       });
+
+      this.preparedOptions = null;
 
       if (!verifyResponse.ok) {
         const errorData = await verifyResponse.json();
@@ -104,9 +131,44 @@ export default class WebauthnRegistrationController extends Controller<HTMLEleme
         alert("登録に失敗しました。");
       }
     } catch (error) {
+      this.preparedOptions = null;
       console.error("WebAuthn 登録エラー:", error);
       alert("エラーが発生しました。再度お試しください。");
     }
+  }
+
+  private async loadOptions(): Promise<RegistrationOptionsResponse> {
+    if (this.preparedOptions) {
+      return this.preparedOptions;
+    }
+
+    if (this.optionsRequest) {
+      return this.optionsRequest;
+    }
+
+    this.optionsRequest = fetch("/users/credentials/new", {
+      method: "GET",
+      cache: "no-store",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    })
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error("登録オプションの取得に失敗しました。");
+        }
+
+        return (await response.json()) as RegistrationOptionsResponse;
+      })
+      .then((options) => {
+        this.preparedOptions = options;
+        return options;
+      })
+      .finally(() => {
+        this.optionsRequest = null;
+      });
+
+    return this.optionsRequest;
   }
 
   // Helper: Base64 → ArrayBuffer


### PR DESCRIPTION
## 目的

パスキー登録 / ログインで、`navigator.credentials.create()` / `get()` がブラウザ側で失敗するケースを修正します。

## 背景

本番ログ上で `GET /users/credentials/new` / `GET /users/webauthn_login` までは到達している一方、対応する `POST` が来ていませんでした。  
そのため、失敗地点はサーバ検証ではなく、ブラウザ側の WebAuthn API 呼び出し前後にあると判断しました。

現状の実装では、クリック後に `fetch()` で options を取得してから `navigator.credentials.create()` / `get()` を呼んでおり、WebKit / Safari 系で user activation の文脈を失って失敗しやすい構成になっていました。

## 変更内容

- `webauthn_registration_controller.ts`
  - `connect()` 時に登録 options を事前取得するよう変更
  - クリック時は、事前取得済み options を優先して `navigator.credentials.create()` を呼ぶよう変更
  - 送信後 / エラー時はキャッシュを破棄して次回取得し直すよう変更

- `webauthn_login_controller.ts`
  - `connect()` 時に認証 options を事前取得するよう変更
  - クリック時は、事前取得済み options を優先して `navigator.credentials.get()` を呼ぶよう変更
  - `allowCredentials` の `id` を `ArrayBuffer` に復元してから利用するよう変更
  - 送信後 / エラー時はキャッシュを破棄して次回取得し直すよう変更

## 期待する効果

- パスキー登録時に、ブラウザ側で `navigator.credentials.create()` が即失敗するケースの改善
- パスキーログイン時に、同様に `navigator.credentials.get()` が user activation 由来で失敗するケースの改善
- 特に Safari / WebKit 系での安定性向上

## 確認内容

- `npm ci`
- `npm run build`

Vite build は成功しています。  
Sass の既存 deprecation warning は出ていますが、今回の変更による build failure はありません。

## 未確認

- Rails / request spec
  - この環境では DB 条件の都合で未実施です
- 実機ブラウザでのパスキー登録 / ログイン確認
  - この PR で確認いただきたいポイントです

## 補足

backend の WebAuthn challenge 取り扱いは README 準拠にさらに寄せる余地がありますが、今回の主因はサーバ verify より前でのブラウザ側失敗と見て、まずは user activation を維持しやすい形への修正を優先しています。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **パフォーマンス改善**
  * WebAuthn ログインおよび登録フローにおいて、オプションの先読み機能を実装し、不要なネットワークリクエストを削減しました
  * 同時に複数のリクエストが発生した場合の重複排除により、より効率的な通信フローを実現しました
  * キャッシング機能により、ログインおよび登録プロセスがより迅速に完了するようになりました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->