### PR TITLE
Update/more useful

### DIFF
--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -38,7 +38,7 @@ jobs:
           no-fail: true
 
       - name: Upload analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2 # v4.32.2
+        uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
         with:
           sarif_file: hadolint-results.sarif
           wait-for-processing: true

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -28,7 +28,7 @@ jobs:
       actions: read
       security-events: write
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
-    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@2a387edfbe02a11d856b89172f6e978100177eb4
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@c51854704019a247608d928f370c98740469d4b5
     with:
       scan-args: |-
         -r
@@ -41,7 +41,7 @@ jobs:
       actions: read
       security-events: write
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
-    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@2a387edfbe02a11d856b89172f6e978100177eb4
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@c51854704019a247608d928f370c98740469d4b5
     with:
       scan-args: |-
         -r

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -48,6 +48,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2
+        uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7
         with:
           sarif_file: results.sarif

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -40,7 +40,7 @@ jobs:
           generateSarif: "1"
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2
+        uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7
         with:
           sarif_file: semgrep.sarif
         if: always()

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -33,14 +33,15 @@ jobs:
         run: docker build -t bokrium:${{ github.sha }} .
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
         with:
           image-ref: "bokrium:${{ github.sha }}"
           format: "sarif"
           output: "trivy-results.sarif"
           severity: "CRITICAL,HIGH"
+          ignore-unfixed: true
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2 # v4.32.2
+        uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
         with:
           sarif_file: "trivy-results.sarif"

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,10 @@ FROM ruby:${RUBY_VERSION}-slim-trixie@sha256:24df04f7b0606fa2f83119ce2f5a16ef9b4
 
 WORKDIR /rails
 
-# hadolint ignore=DL3008
 # 全パッケージのバージョン固定は、Debian のセキュリティ更新時にビルドが壊れやすいため。
 # 再現性はベースイメージ (ruby:4.0.1-slim-trixie) と同一 RUN 内の apt-get update で担保する。
 # CVE-2025-15467 対策: セキュリティアップデートを適用してから他パッケージをインストールする。
+# hadolint ignore=DL3008
 RUN apt-get update -qq && \
     apt-get upgrade -y --no-install-recommends && \
     apt-get install --no-install-recommends -y \
@@ -29,9 +29,9 @@ FROM base AS build
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# hadolint ignore=DL3008
 # 同上（base ステージのコメントを参照）
 # CVE-2025-15467 対策: セキュリティアップデートを適用してから他パッケージをインストールする。
+# hadolint ignore=DL3008
 RUN apt-get update -qq && \
     apt-get upgrade -y --no-install-recommends && \
     apt-get install --no-install-recommends -y \
@@ -68,6 +68,16 @@ FROM base
 
 COPY --from=build ${BUNDLE_PATH} ${BUNDLE_PATH}
 COPY --from=build /rails /rails
+
+# hadolint ignore=DL3008
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y build-essential && \
+    gem install erb:6.0.4 json:2.19.4 --default --no-document && \
+    rm -f \
+      /usr/local/lib/ruby/gems/4.0.0/specifications/default/erb-6.0.1.gemspec \
+      /usr/local/lib/ruby/gems/4.0.0/specifications/default/json-2.18.0.gemspec && \
+    apt-get purge -y --auto-remove build-essential && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives
 
 RUN groupadd --system --gid 1000 rails && \
     useradd rails --uid 1000 --gid 1000 --create-home --shell /bin/bash && \

--- a/Gemfile
+++ b/Gemfile
@@ -64,9 +64,6 @@ gem "solid_cache"
 # 起動高速化
 gem "bootsnap", require: false
 
-# HTTPアセット圧縮・X-Sendfile対応
-gem "thruster", require: false
-
 group :development do
   gem "foreman"
   gem "letter_opener_web"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,7 +163,7 @@ GEM
       railties (>= 6.1)
     drb (2.2.3)
     dry-cli (1.3.0)
-    erb (6.0.3)
+    erb (6.0.4)
     erubi (1.13.1)
     factory_bot (6.5.5)
       activesupport (>= 6.1.0)
@@ -476,11 +476,6 @@ GEM
     stringio (3.2.0)
     stripe (18.3.1)
     thor (1.5.0)
-    thruster (0.1.18)
-    thruster (0.1.18-aarch64-linux)
-    thruster (0.1.18-arm64-darwin)
-    thruster (0.1.18-x86_64-darwin)
-    thruster (0.1.18-x86_64-linux)
     timeout (0.6.1)
     tpm-key_attestation (0.14.1)
       bindata (~> 2.4)
@@ -592,7 +587,6 @@ DEPENDENCIES
   shoulda-matchers
   solid_cache
   stripe
-  thruster
   turbo-rails
   tzinfo-data
   view_component (= 4.2.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,6 +21,11 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:account_update, keys: [ :name, :avatar_s3 ])
   end
 
+  def sign_in_and_remember(resource)
+    resource.remember_me = true if resource.respond_to?(:remember_me=)
+    sign_in(resource)
+  end
+
   private
 
   def browser

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -11,7 +11,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     # すでにLINE連携済みのユーザー
     if (line_user = LineUser.find_by(line_id: line_id))
       user = line_user.user
-      sign_in(user)
+      sign_in_and_remember(user)
       redirect_to mypage_path, notice: "LINEでログインしました。"
       return
     end
@@ -33,7 +33,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     )
     user.create_line_user!(line_id: line_id, line_name: line_name, notifications_enabled: false)
 
-    sign_in(user)
+    sign_in_and_remember(user)
 
     redirect_to guest_starter_books_path, notice: "LINEアカウントで登録・ログインしました。"
   rescue Regexp::TimeoutError => e

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -12,7 +12,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     if (line_user = LineUser.find_by(line_id: line_id))
       user = line_user.user
       sign_in_and_remember(user)
-      redirect_to mypage_path, notice: "LINEでログインしました。"
+      redirect_to books_path, notice: "LINEでログインしました。"
       return
     end
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -92,7 +92,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # The path used after sign up.
   def after_sign_in_path_for(resource)
     stored_location_for(resource) || (
-      resource.sign_in_count == 1 ? guest_starter_books_path : mypage_path
+      resource.sign_in_count == 1 ? guest_starter_books_path : books_path
     )
   end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -20,7 +20,11 @@ class Users::SessionsController < Devise::SessionsController
   #   super
   # end
 
-  # protected
+  protected
+
+  def after_sign_in_path_for(resource)
+    stored_location_for(resource) || books_path
+  end
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_in_params

--- a/app/controllers/users/webauthn_sessions_controller.rb
+++ b/app/controllers/users/webauthn_sessions_controller.rb
@@ -57,7 +57,7 @@ module Users
     private
 
     def after_sign_in_path_for(resource)
-      stored_location_for(resource) || mypage_path
+      stored_location_for(resource) || books_path
     end
   end
 end

--- a/app/controllers/users/webauthn_sessions_controller.rb
+++ b/app/controllers/users/webauthn_sessions_controller.rb
@@ -49,7 +49,7 @@ module Users
       session.delete(:webauthn_authentication_challenge)
 
       user = credential.user
-      sign_in(user)
+      sign_in_and_remember(user)
 
       render json: { success: true, redirect_to: after_sign_in_path_for(user) }
     end

--- a/app/frontend/entrypoints/components/ReadOnlyTipTap.tsx
+++ b/app/frontend/entrypoints/components/ReadOnlyTipTap.tsx
@@ -5,7 +5,7 @@ import React from "react";
 import { useEditor, EditorContent } from "@tiptap/react"
 import StarterKit from "@tiptap/starter-kit"
 import type { ReactElement } from "react"
-import DOMPurify from "dompurify"
+import { createMemoLinkExtension, prepareMemoHtmlForDisplay } from "../utils/memo_links"
 
 interface ReadOnlyTipTapProps {
   content: string
@@ -45,18 +45,28 @@ const removeUnwantedBRs = (html: string): string => {
 }
 
 function ReadOnlyTipTap({ content }: ReadOnlyTipTapProps): ReactElement | null {
-  const sanitized = DOMPurify.sanitize(content)
+  const sanitized = prepareMemoHtmlForDisplay(content)
   const cleaned = removeUnwantedBRs(sanitized)
 
   const editor = useEditor({
-    extensions: [StarterKit],
+    extensions: [StarterKit, createMemoLinkExtension(true)],
     content: cleaned,
     editable: false,
   })
 
   if (!editor) return null
 
-  return <EditorContent editor={editor} />
+  const stopLinkClickPropagation = (event: React.MouseEvent<HTMLDivElement>) => {
+    if ((event.target as HTMLElement).closest("a")) {
+      event.stopPropagation()
+    }
+  }
+
+  return (
+    <div onClickCapture={stopLinkClickPropagation}>
+      <EditorContent editor={editor} />
+    </div>
+  )
 }
 
 export default ReadOnlyTipTap

--- a/app/frontend/entrypoints/components/RichEditor.tsx
+++ b/app/frontend/entrypoints/components/RichEditor.tsx
@@ -7,6 +7,7 @@ import { useEditor, EditorContent, BubbleMenu } from "@tiptap/react"
 import StarterKit from "@tiptap/starter-kit"
 import BubbleMenuExtension from "@tiptap/extension-bubble-menu"
 import CharacterCount from "@tiptap/extension-character-count"
+import { createMemoLinkExtension, prepareMemoHtmlForSave } from "../utils/memo_links"
 
 interface RichEditorProps {
   element: HTMLElement
@@ -49,11 +50,12 @@ const removeUnwantedBRs = (html: string): string => {
 function RichEditor({ element }: RichEditorProps): ReactElement | null {
   const initialRaw = element.dataset.initialContent ?? ""
   const inputId = element.dataset.inputId ?? "memo_content_input"
-  const initialContent = decodeHTML(initialRaw)
+  const initialContent = prepareMemoHtmlForSave(decodeHTML(initialRaw))
 
   const editor = useEditor({
     extensions: [
       StarterKit,
+      createMemoLinkExtension(false),
       BubbleMenuExtension,
       CharacterCount.configure({ limit: 10000 }),
     ],
@@ -70,7 +72,7 @@ function RichEditor({ element }: RichEditorProps): ReactElement | null {
       "[data-action='click->memo-modal#forceSubmit']"
     ) as HTMLButtonElement | null
 
-    let previousHTML = removeUnwantedBRs(editor.getHTML())
+    let previousHTML = prepareMemoHtmlForSave(removeUnwantedBRs(editor.getHTML()))
     if (hiddenField) hiddenField.value = previousHTML
 
     if (saveButton) {
@@ -79,7 +81,7 @@ function RichEditor({ element }: RichEditorProps): ReactElement | null {
     }
 
     const updateHandler = () => {
-      const currentHTML = removeUnwantedBRs(editor.getHTML())
+      const currentHTML = prepareMemoHtmlForSave(removeUnwantedBRs(editor.getHTML()))
 
       if (currentHTML !== previousHTML) {
         if (hiddenField) hiddenField.value = currentHTML

--- a/app/frontend/entrypoints/controllers/memo_modal_controller.ts
+++ b/app/frontend/entrypoints/controllers/memo_modal_controller.ts
@@ -1,5 +1,6 @@
 import { Controller } from "@hotwired/stimulus"
 import { mountRichEditor } from "../rich_editor"
+import { prepareMemoHtmlForSave } from "../utils/memo_links"
 
 
 
@@ -130,7 +131,8 @@ export default class MemoModalController extends Controller<HTMLElement> {
     const trailingBreaks = editorRoot?.querySelectorAll(".ProseMirror-trailingBreak")
     trailingBreaks?.forEach((br) => br.remove())
 
-    const updatedContent = editorRoot?.querySelector(".ProseMirror")?.innerHTML || ""
+    const rawContent = editorRoot?.querySelector(".ProseMirror")?.innerHTML || ""
+    const updatedContent = prepareMemoHtmlForSave(rawContent)
     const hiddenField = document.getElementById("memo_content_input") as HTMLInputElement | null
     if (hiddenField) hiddenField.value = updatedContent
 

--- a/app/frontend/entrypoints/utils/memo_links.ts
+++ b/app/frontend/entrypoints/utils/memo_links.ts
@@ -1,0 +1,166 @@
+import Link from "@tiptap/extension-link"
+import DOMPurify from "dompurify"
+
+export const SAFE_MEMO_LINK_REL = "noopener noreferrer nofollow ugc"
+export const SAFE_MEMO_LINK_TARGET = "_blank"
+
+const SAFE_MEMO_LINK_CLASS = "memo-link"
+const MARKDOWN_LINK_PATTERN = /\[([^\]\n]{1,200})\]\((https?:\/\/[^\s<>"']{1,2048}?)\)/gi
+const SKIP_MARKDOWN_LINK_TAGS = new Set(["A", "CODE", "PRE", "SCRIPT", "STYLE"])
+
+const SAFE_MEMO_TAGS = [
+  "p",
+  "br",
+  "strong",
+  "em",
+  "a",
+  "ul",
+  "ol",
+  "li",
+  "blockquote",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "code",
+  "pre",
+  "span",
+  "hr",
+  "s",
+]
+
+const SAFE_MEMO_ATTRIBUTES = ["href", "title", "target", "rel", "class"]
+
+const hasMarkdownLink = (text: string): boolean => {
+  MARKDOWN_LINK_PATTERN.lastIndex = 0
+  return MARKDOWN_LINK_PATTERN.test(text)
+}
+
+export const normalizeSafeMemoUrl = (value: string | null | undefined): string | null => {
+  const trimmed = value?.trim()
+  if (!trimmed) return null
+
+  try {
+    const url = new URL(trimmed)
+    return url.protocol === "http:" || url.protocol === "https:" ? url.href : null
+  } catch {
+    return null
+  }
+}
+
+const shouldSkipMarkdownLinkNode = (node: Node): boolean => {
+  let parent = node.parentElement
+
+  while (parent) {
+    if (SKIP_MARKDOWN_LINK_TAGS.has(parent.tagName)) return true
+    parent = parent.parentElement
+  }
+
+  return false
+}
+
+export const renderMarkdownLinksToAnchors = (html: string): string => {
+  const template = document.createElement("template")
+  template.innerHTML = html
+
+  const walker = document.createTreeWalker(template.content, NodeFilter.SHOW_TEXT, {
+    acceptNode(node) {
+      if (shouldSkipMarkdownLinkNode(node)) return NodeFilter.FILTER_REJECT
+      return hasMarkdownLink(node.textContent ?? "") ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT
+    },
+  })
+
+  const textNodes: Text[] = []
+  while (walker.nextNode()) {
+    textNodes.push(walker.currentNode as Text)
+  }
+
+  textNodes.forEach((textNode) => {
+    const text = textNode.textContent ?? ""
+    const fragment = document.createDocumentFragment()
+    let cursor = 0
+    let hasReplacement = false
+
+    MARKDOWN_LINK_PATTERN.lastIndex = 0
+    Array.from(text.matchAll(MARKDOWN_LINK_PATTERN)).forEach((match) => {
+      const [raw, label, url] = match
+      const index = match.index ?? 0
+      const safeUrl = normalizeSafeMemoUrl(url)
+      const safeLabel = label.trim()
+
+      if (!safeUrl || !safeLabel) return
+
+      fragment.append(document.createTextNode(text.slice(cursor, index)))
+
+      const anchor = document.createElement("a")
+      anchor.href = safeUrl
+      anchor.target = SAFE_MEMO_LINK_TARGET
+      anchor.rel = SAFE_MEMO_LINK_REL
+      anchor.className = SAFE_MEMO_LINK_CLASS
+      anchor.textContent = safeLabel
+      fragment.append(anchor)
+
+      cursor = index + raw.length
+      hasReplacement = true
+    })
+
+    if (!hasReplacement) return
+
+    fragment.append(document.createTextNode(text.slice(cursor)))
+    textNode.replaceWith(fragment)
+  })
+
+  return template.innerHTML
+}
+
+export const sanitizeMemoHtml = (html: string): string => {
+  const sanitized = DOMPurify.sanitize(html, {
+    ALLOWED_TAGS: SAFE_MEMO_TAGS,
+    ALLOWED_ATTR: SAFE_MEMO_ATTRIBUTES,
+    ALLOWED_URI_REGEXP: /^https?:\/\//i,
+  })
+
+  const template = document.createElement("template")
+  template.innerHTML = sanitized
+
+  template.content.querySelectorAll("a").forEach((anchor) => {
+    const safeUrl = normalizeSafeMemoUrl(anchor.getAttribute("href"))
+
+    if (!safeUrl) {
+      anchor.replaceWith(...Array.from(anchor.childNodes))
+      return
+    }
+
+    anchor.setAttribute("href", safeUrl)
+    anchor.setAttribute("target", SAFE_MEMO_LINK_TARGET)
+    anchor.setAttribute("rel", SAFE_MEMO_LINK_REL)
+    anchor.classList.add(SAFE_MEMO_LINK_CLASS)
+  })
+
+  return template.innerHTML
+}
+
+export const prepareMemoHtmlForSave = (html: string): string => {
+  return sanitizeMemoHtml(renderMarkdownLinksToAnchors(html))
+}
+
+export const prepareMemoHtmlForDisplay = prepareMemoHtmlForSave
+
+export const createMemoLinkExtension = (openOnClick: boolean) => {
+  return Link.configure({
+    autolink: true,
+    linkOnPaste: true,
+    openOnClick,
+    protocols: ["http", "https"],
+    defaultProtocol: "https",
+    HTMLAttributes: {
+      target: SAFE_MEMO_LINK_TARGET,
+      rel: SAFE_MEMO_LINK_REL,
+      class: SAFE_MEMO_LINK_CLASS,
+    },
+    isAllowedUri: (url) => normalizeSafeMemoUrl(url) !== null,
+    shouldAutoLink: (url) => normalizeSafeMemoUrl(url) !== null,
+  })
+}

--- a/app/frontend/entrypoints/utils/memo_links.ts
+++ b/app/frontend/entrypoints/utils/memo_links.ts
@@ -38,6 +38,21 @@ const hasMarkdownLink = (text: string): boolean => {
   return MARKDOWN_LINK_PATTERN.test(text)
 }
 
+const sanitizeMemoHtmlToFragment = (html: string): DocumentFragment => {
+  return DOMPurify.sanitize(html, {
+    ALLOWED_TAGS: SAFE_MEMO_TAGS,
+    ALLOWED_ATTR: SAFE_MEMO_ATTRIBUTES,
+    ALLOWED_URI_REGEXP: /^https?:\/\//i,
+    RETURN_DOM_FRAGMENT: true,
+  })
+}
+
+const serializeMemoFragment = (fragment: DocumentFragment): string => {
+  const template = document.createElement("template")
+  template.content.append(fragment)
+  return template.innerHTML
+}
+
 export const normalizeSafeMemoUrl = (value: string | null | undefined): string | null => {
   const trimmed = value?.trim()
   if (!trimmed) return null
@@ -61,11 +76,8 @@ const shouldSkipMarkdownLinkNode = (node: Node): boolean => {
   return false
 }
 
-export const renderMarkdownLinksToAnchors = (html: string): string => {
-  const template = document.createElement("template")
-  template.innerHTML = html
-
-  const walker = document.createTreeWalker(template.content, NodeFilter.SHOW_TEXT, {
+const renderMarkdownLinksInFragment = (fragment: DocumentFragment): void => {
+  const walker = document.createTreeWalker(fragment, NodeFilter.SHOW_TEXT, {
     acceptNode(node) {
       if (shouldSkipMarkdownLinkNode(node)) return NodeFilter.FILTER_REJECT
       return hasMarkdownLink(node.textContent ?? "") ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT
@@ -111,21 +123,10 @@ export const renderMarkdownLinksToAnchors = (html: string): string => {
     fragment.append(document.createTextNode(text.slice(cursor)))
     textNode.replaceWith(fragment)
   })
-
-  return template.innerHTML
 }
 
-export const sanitizeMemoHtml = (html: string): string => {
-  const sanitized = DOMPurify.sanitize(html, {
-    ALLOWED_TAGS: SAFE_MEMO_TAGS,
-    ALLOWED_ATTR: SAFE_MEMO_ATTRIBUTES,
-    ALLOWED_URI_REGEXP: /^https?:\/\//i,
-  })
-
-  const template = document.createElement("template")
-  template.innerHTML = sanitized
-
-  template.content.querySelectorAll("a").forEach((anchor) => {
+const enforceSafeMemoAnchors = (root: ParentNode): void => {
+  root.querySelectorAll("a").forEach((anchor) => {
     const safeUrl = normalizeSafeMemoUrl(anchor.getAttribute("href"))
 
     if (!safeUrl) {
@@ -138,12 +139,23 @@ export const sanitizeMemoHtml = (html: string): string => {
     anchor.setAttribute("rel", SAFE_MEMO_LINK_REL)
     anchor.classList.add(SAFE_MEMO_LINK_CLASS)
   })
+}
 
-  return template.innerHTML
+export const renderMarkdownLinksToAnchors = (html: string): string => {
+  const fragment = sanitizeMemoHtmlToFragment(html)
+  renderMarkdownLinksInFragment(fragment)
+  enforceSafeMemoAnchors(fragment)
+  return serializeMemoFragment(fragment)
+}
+
+export const sanitizeMemoHtml = (html: string): string => {
+  const fragment = sanitizeMemoHtmlToFragment(html)
+  enforceSafeMemoAnchors(fragment)
+  return serializeMemoFragment(fragment)
 }
 
 export const prepareMemoHtmlForSave = (html: string): string => {
-  return sanitizeMemoHtml(renderMarkdownLinksToAnchors(html))
+  return renderMarkdownLinksToAnchors(html)
 }
 
 export const prepareMemoHtmlForDisplay = prepareMemoHtmlForSave

--- a/app/frontend/styles/_tip_tap.scss
+++ b/app/frontend/styles/_tip_tap.scss
@@ -66,6 +66,13 @@ em {
   margin: 0.5em 0;
 }
 
+.ProseMirror a,
+.memo-link {
+  color: #0b63ce;
+  text-decoration: underline;
+  text-underline-offset: 0.16em;
+}
+
 .ProseMirror:focus {
   outline: none;
 }

--- a/app/helpers/memos_helper.rb
+++ b/app/helpers/memos_helper.rb
@@ -1,5 +1,12 @@
 module MemosHelper
   PLACEHOLDER_TOKEN = "PLACEHOLDER_TOKEN_9fz3!ifhdas094hfgfygq@_$2x"
+  SAFE_MEMO_LINK_REL = "noopener noreferrer nofollow ugc"
+  SAFE_MEMO_LINK_TARGET = "_blank"
+  SAFE_MEMO_LINK_CLASS = "memo-link"
+  SAFE_MEMO_CONTENT_TAGS = %w[p br strong em a ul ol li blockquote h1 h2 h3 h4 h5 h6 code pre span hr s].freeze
+  SAFE_MEMO_CONTENT_ATTRIBUTES = %w[href title target rel class].freeze
+  MARKDOWN_LINK_PATTERN = /\[([^\]\n]{1,200})\]\((https?:\/\/[^\s<>"']{1,2048}?)\)/i
+  SKIP_MARKDOWN_LINK_TAGS = %w[a code pre script style].freeze
 
   def memo_placeholder_html
     raw_html = <<~HTML
@@ -37,5 +44,96 @@ module MemosHelper
     renderer = Redcarpet::Render::HTML.new(filter_html: true, hard_wrap: true)
     markdown = Redcarpet::Markdown.new(renderer, autolink: true, tables: true)
     markdown.render(text)
+  end
+
+  def render_memo_content(content)
+    html = convert_markdown_links_to_html(content.to_s)
+    sanitized = sanitize(html, tags: SAFE_MEMO_CONTENT_TAGS, attributes: SAFE_MEMO_CONTENT_ATTRIBUTES)
+    enforce_safe_memo_links(sanitized)
+  end
+
+  private
+
+  def convert_markdown_links_to_html(html)
+    fragment = Nokogiri::HTML::DocumentFragment.parse(html)
+    text_nodes = []
+
+    fragment.traverse do |node|
+      text_nodes << node if node.text?
+    end
+
+    text_nodes.each do |node|
+      next if node.ancestors.any? { |ancestor| SKIP_MARKDOWN_LINK_TAGS.include?(ancestor.name) }
+      next unless node.text.match?(MARKDOWN_LINK_PATTERN)
+
+      replace_markdown_links_in_node(node)
+    end
+
+    fragment.to_html
+  end
+
+  def replace_markdown_links_in_node(node)
+    text = node.text
+    document = node.document
+    replacement = Nokogiri::HTML::DocumentFragment.parse("")
+    cursor = 0
+    replaced = false
+
+    text.to_enum(:scan, MARKDOWN_LINK_PATTERN).each do
+      match = Regexp.last_match
+      safe_href = normalize_safe_memo_url(match[2])
+      label = match[1].to_s.strip
+      next if safe_href.blank? || label.blank?
+
+      replacement.add_child(Nokogiri::XML::Text.new(text[cursor...match.begin(0)], document))
+      replacement.add_child(memo_link_node(document, label, safe_href))
+      cursor = match.end(0)
+      replaced = true
+    end
+
+    return unless replaced
+
+    replacement.add_child(Nokogiri::XML::Text.new(text[cursor..], document))
+    node.replace(replacement)
+  end
+
+  def memo_link_node(document, label, href)
+    link = Nokogiri::XML::Node.new("a", document)
+    link["href"] = href
+    link["target"] = SAFE_MEMO_LINK_TARGET
+    link["rel"] = SAFE_MEMO_LINK_REL
+    link["class"] = SAFE_MEMO_LINK_CLASS
+    link.content = label
+    link
+  end
+
+  def enforce_safe_memo_links(html)
+    fragment = Nokogiri::HTML::DocumentFragment.parse(html.to_s)
+
+    fragment.css("a").each do |link|
+      safe_href = normalize_safe_memo_url(link["href"])
+
+      unless safe_href
+        link.replace(link.children)
+        next
+      end
+
+      link["href"] = safe_href
+      link["target"] = SAFE_MEMO_LINK_TARGET
+      link["rel"] = SAFE_MEMO_LINK_REL
+      link["class"] = [ link["class"], SAFE_MEMO_LINK_CLASS ].compact.join(" ")
+    end
+
+    fragment.to_html.html_safe
+  end
+
+  def normalize_safe_memo_url(value)
+    uri = URI.parse(value.to_s.strip)
+    return unless uri.is_a?(URI::HTTP) && uri.host.present?
+    return unless %w[http https].include?(uri.scheme)
+
+    uri.to_s
+  rescue URI::InvalidURIError
+    nil
   end
 end

--- a/app/mailers/memo_mailer.rb
+++ b/app/mailers/memo_mailer.rb
@@ -1,9 +1,10 @@
 class MemoMailer < ApplicationMailer
+  helper MemosHelper
+
   def random_memo_email(user, memo)
     @user = user
     @memo = memo
     @book = memo.book
-    @html_content = @memo.content.to_s # ← Redcarpet不要！
 
     mail(
       to: @user.email,

--- a/app/views/memo_mailer/random_memo_email.html.erb
+++ b/app/views/memo_mailer/random_memo_email.html.erb
@@ -16,7 +16,7 @@
   </p>
 
   <div style="background-color: #fff; padding: 1em; border: 1px solid #ddd; border-radius: 6px; margin-bottom: 1.5em; line-height: 1.6; font-size: 1em;">
-    <%= raw @html_content %>
+    <%= render_memo_content(@memo.content) %>
   </div>
 
   <p style="margin-top: 1em; font-size: 0.95em;">

--- a/app/views/public_bookshelf/show.html.erb
+++ b/app/views/public_bookshelf/show.html.erb
@@ -19,9 +19,7 @@
         </div>
         <!-- メモ本文 -->
         <div class="card-body rhodia-grid-bg px-4 py-3">
-          <%= sanitize(@memo.content,
-            tags: %w(p br strong em a ul ol li blockquote h1 h2 h3 h4 h5 h6 code pre span hr),
-            attributes: %w(href title class data-* style)) || memo_placeholder_html %>
+          <%= @memo.content.present? ? render_memo_content(@memo.content) : memo_placeholder_html %>
         </div>
         <!-- 更新情報 -->
         <div class="card-footer d-flex justify-content-between small text-muted">

--- a/bin/thrust
+++ b/bin/thrust
@@ -1,5 +1,0 @@
-#!/usr/bin/env ruby
-require "rubygems"
-require "bundler/setup"
-
-load Gem.bin_path("thruster", "thrust")

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -23,6 +23,10 @@ Devise.setup do |config|
 
   config.reconfirmable = true
 
+  config.remember_for = 1.month
+
+  config.extend_remember_period = true
+
   config.expire_all_remember_me_on_sign_out = true
 
   config.password_length = 6..128

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: {
+    sessions: "users/sessions",
     registrations: "users/registrations",
     confirmations: "users/confirmations",
     passwords: "users/passwords",

--- a/db/migrate/20250503122140_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20250503122140_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -3,13 +3,13 @@
 # This migration comes from acts_as_taggable_on_engine (originally 1)
 class ActsAsTaggableOnMigration < ActiveRecord::Migration[6.0]
   def self.up
-    create_table ActsAsTaggableOn.tags_table do |t|
+    create_table :tags do |t|
       t.string :name
       t.timestamps
     end
 
-    create_table ActsAsTaggableOn.taggings_table do |t|
-      t.references :tag, foreign_key: { to_table: ActsAsTaggableOn.tags_table }
+    create_table :taggings do |t|
+      t.references :tag, foreign_key: { to_table: :tags }
 
       # You should make sure that the column created is
       # long enough to store the required class names.
@@ -23,12 +23,12 @@ class ActsAsTaggableOnMigration < ActiveRecord::Migration[6.0]
       t.datetime :created_at
     end
 
-    add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type context],
+    add_index :taggings, %i[taggable_id taggable_type context],
               name: 'taggings_taggable_context_idx'
   end
 
   def self.down
-    drop_table ActsAsTaggableOn.taggings_table
-    drop_table ActsAsTaggableOn.tags_table
+    drop_table :taggings
+    drop_table :tags
   end
 end

--- a/db/migrate/20250503122141_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20250503122141_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -3,22 +3,22 @@
 # This migration comes from acts_as_taggable_on_engine (originally 2)
 class AddMissingUniqueIndices < ActiveRecord::Migration[6.0]
   def self.up
-    add_index ActsAsTaggableOn.tags_table, :name, unique: true
+    add_index :tags, :name, unique: true
 
-    remove_index ActsAsTaggableOn.taggings_table, :tag_id if index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
-    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
-    add_index ActsAsTaggableOn.taggings_table,
+    remove_index :taggings, :tag_id if index_exists?(:taggings, :tag_id)
+    remove_index :taggings, name: 'taggings_taggable_context_idx'
+    add_index :taggings,
               %i[tag_id taggable_id taggable_type context tagger_id tagger_type],
               unique: true, name: 'taggings_idx'
   end
 
   def self.down
-    remove_index ActsAsTaggableOn.tags_table, :name
+    remove_index :tags, :name
 
-    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_idx'
+    remove_index :taggings, name: 'taggings_idx'
 
-    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
-    add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type context],
+    add_index :taggings, :tag_id unless index_exists?(:taggings, :tag_id)
+    add_index :taggings, %i[taggable_id taggable_type context],
               name: 'taggings_taggable_context_idx'
   end
 end

--- a/db/migrate/20250503122142_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20250503122142_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -3,15 +3,21 @@
 # This migration comes from acts_as_taggable_on_engine (originally 3)
 class AddTaggingsCounterCacheToTags < ActiveRecord::Migration[6.0]
   def self.up
-    add_column ActsAsTaggableOn.tags_table, :taggings_count, :integer, default: 0
+    add_column :tags, :taggings_count, :integer, default: 0
 
-    ActsAsTaggableOn::Tag.reset_column_information
-    ActsAsTaggableOn::Tag.find_each do |tag|
-      ActsAsTaggableOn::Tag.reset_counters(tag.id, ActsAsTaggableOn.taggings_table)
-    end
+    execute <<~SQL.squish
+      UPDATE tags
+      SET taggings_count = taggings_counts.count
+      FROM (
+        SELECT tag_id, COUNT(*) AS count
+        FROM taggings
+        GROUP BY tag_id
+      ) AS taggings_counts
+      WHERE tags.id = taggings_counts.tag_id
+    SQL
   end
 
   def self.down
-    remove_column ActsAsTaggableOn.tags_table, :taggings_count
+    remove_column :tags, :taggings_count
   end
 end

--- a/db/migrate/20250503122143_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20250503122143_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -3,11 +3,11 @@
 # This migration comes from acts_as_taggable_on_engine (originally 4)
 class AddMissingTaggableIndex < ActiveRecord::Migration[6.0]
   def self.up
-    add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type context],
+    add_index :taggings, %i[taggable_id taggable_type context],
               name: 'taggings_taggable_context_idx'
   end
 
   def self.down
-    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+    remove_index :taggings, name: 'taggings_taggable_context_idx'
   end
 end

--- a/db/migrate/20250503122144_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20250503122144_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -6,8 +6,8 @@
 
 class ChangeCollationForTagNames < ActiveRecord::Migration[6.0]
   def up
-    if ActsAsTaggableOn::Utils.using_mysql?
-      execute("ALTER TABLE #{ActsAsTaggableOn.tags_table} MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
+    if connection.adapter_name.downcase.include?("mysql")
+      execute("ALTER TABLE tags MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
     end
   end
 end

--- a/db/migrate/20250503122145_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20250503122145_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
@@ -3,23 +3,18 @@
 # This migration comes from acts_as_taggable_on_engine (originally 6)
 class AddMissingIndexesOnTaggings < ActiveRecord::Migration[6.0]
   def change
-    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists? ActsAsTaggableOn.taggings_table, :tag_id
-    add_index ActsAsTaggableOn.taggings_table, :taggable_id unless index_exists? ActsAsTaggableOn.taggings_table,
-                                                                                 :taggable_id
-    add_index ActsAsTaggableOn.taggings_table, :taggable_type unless index_exists? ActsAsTaggableOn.taggings_table,
-                                                                                   :taggable_type
-    add_index ActsAsTaggableOn.taggings_table, :tagger_id unless index_exists? ActsAsTaggableOn.taggings_table,
-                                                                               :tagger_id
-    add_index ActsAsTaggableOn.taggings_table, :context unless index_exists? ActsAsTaggableOn.taggings_table, :context
+    add_index :taggings, :tag_id unless index_exists? :taggings, :tag_id
+    add_index :taggings, :taggable_id unless index_exists? :taggings, :taggable_id
+    add_index :taggings, :taggable_type unless index_exists? :taggings, :taggable_type
+    add_index :taggings, :tagger_id unless index_exists? :taggings, :tagger_id
+    add_index :taggings, :context unless index_exists? :taggings, :context
 
-    unless index_exists? ActsAsTaggableOn.taggings_table, %i[tagger_id tagger_type]
-      add_index ActsAsTaggableOn.taggings_table, %i[tagger_id tagger_type]
+    unless index_exists? :taggings, %i[tagger_id tagger_type]
+      add_index :taggings, %i[tagger_id tagger_type]
     end
 
-    unless index_exists? ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type tagger_id context],
-                         name: 'taggings_idy'
-      add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type tagger_id context],
-                name: 'taggings_idy'
+    unless index_exists? :taggings, %i[taggable_id taggable_type tagger_id context], name: 'taggings_idy'
+      add_index :taggings, %i[taggable_id taggable_type tagger_id context], name: 'taggings_idy'
     end
   end
 end

--- a/db/migrate/20250503122146_add_tenant_to_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20250503122146_add_tenant_to_taggings.acts_as_taggable_on_engine.rb
@@ -3,12 +3,12 @@
 # This migration comes from acts_as_taggable_on_engine (originally 7)
 class AddTenantToTaggings < ActiveRecord::Migration[6.0]
   def self.up
-    add_column ActsAsTaggableOn.taggings_table, :tenant, :string, limit: 128
-    add_index ActsAsTaggableOn.taggings_table, :tenant unless index_exists? ActsAsTaggableOn.taggings_table, :tenant
+    add_column :taggings, :tenant, :string, limit: 128
+    add_index :taggings, :tenant unless index_exists? :taggings, :tenant
   end
 
   def self.down
-    remove_index ActsAsTaggableOn.taggings_table, :tenant
-    remove_column ActsAsTaggableOn.taggings_table, :tenant
+    remove_index :taggings, :tenant
+    remove_column :taggings, :tenant
   end
 end

--- a/fly.toml
+++ b/fly.toml
@@ -15,13 +15,18 @@ console_command = '/rails/bin/rails console'
 [processes]
   app = './bin/rails server -b 0.0.0.0 -p 8080'
 
+[[vm]]
+  size = 'shared-cpu-1x'
+  memory = '768mb'
+  processes = ['app']
+
 [deploy]
   release_command = "bash -c 'DATABASE_URL=$DIRECT_DATABASE_URL bundle exec rails db:migrate'"
 
 [http_service]
   internal_port = 8080
   force_https = true
-  auto_stop_machines = "suspend" 
+  auto_stop_machines = "suspend"
   auto_start_machines = true
   min_machines_running = 1
   processes = ['app']

--- a/package-lock.json
+++ b/package-lock.json
@@ -869,9 +869,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.45.1.tgz",
-      "integrity": "sha512-NEySIFvMY0ZQO+utJkgoMiCAjMrGvnbDLHvcmlA33UXJpYBCvlBEbMMtV837uCkS+plG2umfhn0T5mMAxGrlRA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
       "cpu": [
         "arm"
       ],
@@ -883,9 +883,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.45.1.tgz",
-      "integrity": "sha512-ujQ+sMXJkg4LRJaYreaVx7Z/VMgBBd89wGS4qMrdtfUFZ+TSY5Rs9asgjitLwzeIbhwdEhyj29zhst3L1lKsRQ==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
       "cpu": [
         "arm64"
       ],
@@ -897,9 +897,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.45.1.tgz",
-      "integrity": "sha512-FSncqHvqTm3lC6Y13xncsdOYfxGSLnP+73k815EfNmpewPs+EyM49haPS105Rh4aF5mJKywk9X0ogzLXZzN9lA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
       "cpu": [
         "arm64"
       ],
@@ -911,9 +911,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.45.1.tgz",
-      "integrity": "sha512-2/vVn/husP5XI7Fsf/RlhDaQJ7x9zjvC81anIVbr4b/f0xtSmXQTFcGIQ/B1cXIYM6h2nAhJkdMHTnD7OtQ9Og==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
       "cpu": [
         "x64"
       ],
@@ -925,9 +925,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.45.1.tgz",
-      "integrity": "sha512-4g1kaDxQItZsrkVTdYQ0bxu4ZIQ32cotoQbmsAnW1jAE4XCMbcBPDirX5fyUzdhVCKgPcrwWuucI8yrVRBw2+g==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
       "cpu": [
         "arm64"
       ],
@@ -939,9 +939,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.45.1.tgz",
-      "integrity": "sha512-L/6JsfiL74i3uK1Ti2ZFSNsp5NMiM4/kbbGEcOCps99aZx3g8SJMO1/9Y0n/qKlWZfn6sScf98lEOUe2mBvW9A==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
       "cpu": [
         "x64"
       ],
@@ -953,9 +953,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.45.1.tgz",
-      "integrity": "sha512-RkdOTu2jK7brlu+ZwjMIZfdV2sSYHK2qR08FUWcIoqJC2eywHbXr0L8T/pONFwkGukQqERDheaGTeedG+rra6Q==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
       "cpu": [
         "arm"
       ],
@@ -967,9 +967,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.45.1.tgz",
-      "integrity": "sha512-3kJ8pgfBt6CIIr1o+HQA7OZ9mp/zDk3ctekGl9qn/pRBgrRgfwiffaUmqioUGN9hv0OHv2gxmvdKOkARCtRb8Q==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
       "cpu": [
         "arm"
       ],
@@ -981,9 +981,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.45.1.tgz",
-      "integrity": "sha512-k3dOKCfIVixWjG7OXTCOmDfJj3vbdhN0QYEqB+OuGArOChek22hn7Uy5A/gTDNAcCy5v2YcXRJ/Qcnm4/ma1xw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
       "cpu": [
         "arm64"
       ],
@@ -995,9 +995,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.45.1.tgz",
-      "integrity": "sha512-PmI1vxQetnM58ZmDFl9/Uk2lpBBby6B6rF4muJc65uZbxCs0EA7hhKCk2PKlmZKuyVSHAyIw3+/SiuMLxKxWog==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
       "cpu": [
         "arm64"
       ],
@@ -1008,10 +1008,10 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.45.1.tgz",
-      "integrity": "sha512-9UmI0VzGmNJ28ibHW2GpE2nF0PBQqsyiS4kcJ5vK+wuwGnV5RlqdczVocDSUfGX/Na7/XINRVoUgJyFIgipoRg==",
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
       "cpu": [
         "loong64"
       ],
@@ -1022,10 +1022,38 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.45.1.tgz",
-      "integrity": "sha512-7nR2KY8oEOUTD3pBAxIBBbZr0U7U+R9HDTPNy+5nVVHDXI4ikYniH1oxQz9VoB5PbBU1CZuDGHkLJkd3zLMWsg==",
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1037,9 +1065,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.45.1.tgz",
-      "integrity": "sha512-nlcl3jgUultKROfZijKjRQLUu9Ma0PeNv/VFHkZiKbXTBQXhpytS8CIj5/NfBeECZtY2FJQubm6ltIxm/ftxpw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
       "cpu": [
         "riscv64"
       ],
@@ -1051,9 +1079,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.45.1.tgz",
-      "integrity": "sha512-HJV65KLS51rW0VY6rvZkiieiBnurSzpzore1bMKAhunQiECPuxsROvyeaot/tcK3A3aGnI+qTHqisrpSgQrpgA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1065,9 +1093,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.45.1.tgz",
-      "integrity": "sha512-NITBOCv3Qqc6hhwFt7jLV78VEO/il4YcBzoMGGNxznLgRQf43VQDae0aAzKiBeEPIxnDrACiMgbqjuihx08OOw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
       "cpu": [
         "s390x"
       ],
@@ -1079,9 +1107,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.45.1.tgz",
-      "integrity": "sha512-+E/lYl6qu1zqgPEnTrs4WysQtvc/Sh4fC2nByfFExqgYrqkKWp1tWIbe+ELhixnenSpBbLXNi6vbEEJ8M7fiHw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
       "cpu": [
         "x64"
       ],
@@ -1093,9 +1121,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.45.1.tgz",
-      "integrity": "sha512-a6WIAp89p3kpNoYStITT9RbTbTnqarU7D8N8F2CV+4Cl9fwCOZraLVuVFvlpsW0SbIiYtEnhCZBPLoNdRkjQFw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
       "cpu": [
         "x64"
       ],
@@ -1106,10 +1134,38 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.45.1.tgz",
-      "integrity": "sha512-T5Bi/NS3fQiJeYdGvRpTAP5P02kqSOpqiopwhj0uaXB6nzs5JVi2XMJb18JUSKhCOX8+UE1UKQufyD6Or48dJg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
       "cpu": [
         "arm64"
       ],
@@ -1121,9 +1177,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.45.1.tgz",
-      "integrity": "sha512-lxV2Pako3ujjuUe9jiU3/s7KSrDfH6IgTSQOnDWr9aJ92YsFd7EurmClK0ly/t8dzMkDtd04g60WX6yl0sGfdw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
       "cpu": [
         "ia32"
       ],
@@ -1134,10 +1190,24 @@
         "win32"
       ]
     },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.45.1.tgz",
-      "integrity": "sha512-M/fKi4sasCdM8i0aWJjCSFm2qEnYRR8AMLG2kxp6wD13+tMGA4Z1tVAuHkNRjud5SW2EM3naLuK35w9twvf6aA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
       "cpu": [
         "x64"
       ],
@@ -1764,9 +1834,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
-      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -1913,9 +1983,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.3.tgz",
-      "integrity": "sha512-+chQdDfvscSF1SJqv2gn4SRO2ZyS3xL3r7IW/wWEEzrzLisnOlKiQu5ytC/BVNcS15C39WT2Hg/bjKjDMcu+zg==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
+      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
       "dev": true,
       "license": "MIT"
     },
@@ -1962,9 +2032,9 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
@@ -2056,9 +2126,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2116,9 +2186,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "dev": true,
       "funding": [
         {
@@ -2416,9 +2486,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.45.1.tgz",
-      "integrity": "sha512-4iya7Jb76fVpQyLoiVpzUrsjQ12r3dM7fIVz+4NwoYvZOShknRmiv+iu9CClZml5ZLGb0XMcYLutK6w9tgxHDw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2432,26 +2502,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.45.1",
-        "@rollup/rollup-android-arm64": "4.45.1",
-        "@rollup/rollup-darwin-arm64": "4.45.1",
-        "@rollup/rollup-darwin-x64": "4.45.1",
-        "@rollup/rollup-freebsd-arm64": "4.45.1",
-        "@rollup/rollup-freebsd-x64": "4.45.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.45.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.45.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.45.1",
-        "@rollup/rollup-linux-arm64-musl": "4.45.1",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.45.1",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.45.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.45.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.45.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.45.1",
-        "@rollup/rollup-linux-x64-gnu": "4.45.1",
-        "@rollup/rollup-linux-x64-musl": "4.45.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.45.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.45.1",
-        "@rollup/rollup-win32-x64-msvc": "4.45.1",
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
         "fsevents": "~2.3.2"
       }
     },
@@ -2564,9 +2639,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2624,9 +2699,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.0.tgz",
-      "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2731,9 +2806,9 @@
       }
     },
     "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@popperjs/core": "^2.11.8",
         "@tiptap/extension-bubble-menu": "^2.11.9",
         "@tiptap/extension-character-count": "^2.11.9",
+        "@tiptap/extension-link": "^2.12.0",
         "@tiptap/react": "^2.11.9",
         "@tiptap/starter-kit": "^2.11.9",
         "@zxing/browser": "^0.1.5",
@@ -1453,6 +1454,23 @@
         "@tiptap/core": "^2.7.0"
       }
     },
+    "node_modules/@tiptap/extension-link": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-2.12.0.tgz",
+      "integrity": "sha512-N6f78F2onvcL8FAwFOJexOF02UwGETLjQ7cCguhBe/w7vtx7aX8/f+IlaSGY/pIcWyEQpoC28ciM0+QsrJRr1A==",
+      "license": "MIT",
+      "dependencies": {
+        "linkifyjs": "^4.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
     "node_modules/@tiptap/extension-list-item": {
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-2.12.0.tgz",
@@ -2030,6 +2048,12 @@
       "dependencies": {
         "uc.micro": "^2.0.0"
       }
+    },
+    "node_modules/linkifyjs": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
+      "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
+      "license": "MIT"
     },
     "node_modules/markdown-it": {
       "version": "14.1.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@popperjs/core": "^2.11.8",
     "@tiptap/extension-bubble-menu": "^2.11.9",
     "@tiptap/extension-character-count": "^2.11.9",
+    "@tiptap/extension-link": "^2.12.0",
     "@tiptap/react": "^2.11.9",
     "@tiptap/starter-kit": "^2.11.9",
     "@zxing/browser": "^0.1.5",

--- a/spec/helpers/memos_helper_spec.rb
+++ b/spec/helpers/memos_helper_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe MemosHelper, type: :helper do
+  describe "#render_memo_content" do
+    it "renders markdown http and https links as safe anchors" do
+      html = helper.render_memo_content("[公式サイト](https://example.com/path?q=1)")
+
+      expect(html).to include('<a href="https://example.com/path?q=1"')
+      expect(html).to include('target="_blank"')
+      expect(html).to include('rel="noopener noreferrer nofollow ugc"')
+      expect(html).to include(">公式サイト</a>")
+    end
+
+    it "does not render unsafe markdown URLs as anchors" do
+      html = helper.render_memo_content("[危険](javascript:alert(1))")
+
+      expect(html).to include("[危険](javascript:alert(1))")
+      expect(html).not_to include("<a")
+    end
+
+    it "removes unsafe hrefs from raw HTML anchors" do
+      html = helper.render_memo_content('<a href="javascript:alert(1)">危険</a>')
+
+      expect(html).to include("危険")
+      expect(html).not_to include("<a")
+      expect(html).not_to include("javascript:")
+    end
+
+    it "removes script tags and event handlers" do
+      html = helper.render_memo_content('<p onclick="alert(1)">本文</p><script>alert(1)</script>')
+
+      expect(html).to include("<p>本文</p>")
+      expect(html).not_to include("onclick")
+      expect(html).not_to include("<script")
+    end
+  end
+end

--- a/spec/initializers/devise_spec.rb
+++ b/spec/initializers/devise_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Devise initializer" do
+  it "keeps remember me cookies for one month and extends them on access" do
+    expect(Devise.remember_for).to eq(1.month)
+    expect(Devise.extend_remember_period).to be(true)
+  end
+end

--- a/spec/requests/users/omniauth_callbacks_spec.rb
+++ b/spec/requests/users/omniauth_callbacks_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Users::OmniauthCallbacks", type: :request do
+  around do |example|
+    original_test_mode = OmniAuth.config.test_mode
+    original_mock_auth = OmniAuth.config.mock_auth[:line]
+    OmniAuth.config.test_mode = true
+
+    example.run
+  ensure
+    OmniAuth.config.test_mode = original_test_mode
+    OmniAuth.config.mock_auth[:line] = original_mock_auth
+    Rails.application.env_config.delete("omniauth.auth")
+  end
+
+  describe "GET /users/auth/line/callback" do
+    let(:auth_hash) do
+      OmniAuth::AuthHash.new(
+        provider: "line",
+        uid: "line-user-id",
+        info: { name: "LINE User" }
+      )
+    end
+
+    before do
+      OmniAuth.config.mock_auth[:line] = auth_hash
+      Rails.application.env_config["omniauth.auth"] = auth_hash
+    end
+
+    it "remembers an existing LINE user after sign in" do
+      user = create(:user)
+      create(:line_user, user: user, line_id: "line-user-id")
+
+      get "/users/auth/line/callback"
+
+      expect(response).to redirect_to(mypage_path)
+      expect(user.reload.remember_created_at).to be_present
+    end
+
+    it "remembers a newly created LINE user after sign in" do
+      get "/users/auth/line/callback"
+
+      user = User.find_by!(auth_provider: "line")
+      expect(response).to redirect_to(guest_starter_books_path)
+      expect(user.remember_created_at).to be_present
+    end
+  end
+end

--- a/spec/requests/users/omniauth_callbacks_spec.rb
+++ b/spec/requests/users/omniauth_callbacks_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "Users::OmniauthCallbacks", type: :request do
 
       get "/users/auth/line/callback"
 
-      expect(response).to redirect_to(mypage_path)
+      expect(response).to redirect_to(books_path)
       expect(user.reload.remember_created_at).to be_present
     end
 

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Users::Sessions", type: :request do
+  describe "POST /users/sign_in" do
+    it "redirects to the books index after sign in" do
+      user = create(:user, password: "password123")
+      create(:book, user: user)
+
+      post user_session_path, params: {
+        user: {
+          email: user.email,
+          password: "password123"
+        }
+      }
+
+      expect(response).to redirect_to(books_path)
+    end
+  end
+end

--- a/spec/requests/users/webauthn_sessions_spec.rb
+++ b/spec/requests/users/webauthn_sessions_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe "Users::WebauthnSessions (パスキーログイン)", type: :requ
       # サインインしていることを確認（mypage にアクセスして 200 になる）
       get mypage_path
       expect(response).to have_http_status(:ok)
+      expect(user.reload.remember_created_at).to be_present
     end
   end
 end

--- a/spec/requests/users/webauthn_sessions_spec.rb
+++ b/spec/requests/users/webauthn_sessions_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Users::WebauthnSessions (パスキーログイン)", type: :requ
       expect(response).to have_http_status(:ok)
       json = response.parsed_body
       expect(json["success"]).to eq(true)
-      expect(json["redirect_to"]).to eq(mypage_path)
+      expect(json["redirect_to"]).to eq(books_path)
 
       # サインインしていることを確認（mypage にアクセスして 200 になる）
       get mypage_path

--- a/spec/system/users/confirmation_spec.rb
+++ b/spec/system/users/confirmation_spec.rb
@@ -46,11 +46,12 @@ RSpec.describe 'User login after confirmation', type: :system do
   before do
     driven_by :rack_test
 
-    User.create!(
+    user = User.create!(
       email: email,
       password: password,
       confirmed_at: Time.current
     )
+    create(:book, user: user)
   end
 
   it 'メール確認済みのユーザーが正常にログインできること' do
@@ -60,6 +61,6 @@ RSpec.describe 'User login after confirmation', type: :system do
     click_button 'ログイン'
 
     expect(page).to have_content 'ログインしました'
-    expect(page).to have_current_path(root_path)
+    expect(page).to have_current_path(books_path)
   end
 end


### PR DESCRIPTION
そのまま貼れる形です。

## 概要

Bokrium のセキュリティチェック対応、ログイン保持改善、メモ内リンク対応、古い migration の修正、ログイン後遷移先の変更を行いました。

## 変更内容

- CI / セキュリティスキャン対応
  - Trivy / OSV / Semgrep / Scorecard / Hadolint 周辺の警告に対応
  - Dockerfile の脆弱性対応と不要 dependency の整理
  - Trivy は未修正 CVE を除外する設定に調整

- ログイン保持の改善
  - Devise の remember period を 2週間から 1か月に延長
  - `extend_remember_period` を有効化
  - パスキー / LINE ログインでも remember me が有効になるよう対応

- メモ内リンク対応
  - `[表示テキスト](https://example.com)` 形式のリンクをクリック可能に変換
  - `http` / `https` のみ許可
  - `javascript:` など危険なリンクはクリック不可
  - 表示・保存・メール・公開メモ側で共通のサニタイズ処理を適用
  - メモ内Markdownリンク変換をDOMPurifyでサニタイズ済みのDOM上で処理するようにし、XSSリスクとCodeQL警告を解消しました。

- migration 修正
  - 既に使っていない `acts_as_taggable_on` gem に依存していた古い migration を自己完結化
  - 新規DB / 未適用DBでも migration が通るように修正

- ログイン後遷移先変更
  - 通常ログイン / パスキーログイン / 既存LINEログイン後の遷移先を `mypage` から books index に変更
 
- Fly.io コスト最適化
  - fly.toml に [[vm]] 設定を追加
  - app process group の VM を shared-cpu-1x / 768mb に固定
  - 次回 deploy 時に 1GB 設定へ戻らないように調整

## 確認内容

- pre-push RSpec
  - `258 examples, 0 failures, 2 pending`
- RuboCop
  - no offenses
- development DB migration
  - `rails db:migrate` 成功
- test DB migration
  - `db:drop db:create db:migrate` 成功
- フロントエンド build
  - `npm run build` 成功
- npm audit
  - high 以上の脆弱性なし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **新機能**
  * ユーザーがログイン時に「ログイン状態を保持」できるようになりました。
  * メモ内のリンク処理を改善し、マークダウン形式のリンクをHTMLアンカータグに変換できるようになりました。
  * メモコンテンツのセキュリティが強化され、HTML サニタイズが実装されました。

* **改善**
  * ログイン後のリダイレクト先が改善されました。

* **チョア**
  * GitHub Actions ワークフローを更新しました。
  * 依存関係を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->