### PR TITLE
Add live bookshelf autocomplete search

### DIFF
--- a/app/components/books/b_note_component.html.erb
+++ b/app/components/books/b_note_component.html.erb
@@ -38,7 +38,7 @@
 
 <% if @pagy.next %>
   <turbo-frame id="next_books"
-               src="<%= helpers.books_index_path(view: 'b_note', page: @pagy.next) %>"
+               src="<%= @next_page_path || helpers.books_index_path(view: 'b_note', page: @pagy.next) %>"
                loading="lazy">
     <%= render "shared/loading_spinner" %>
   </turbo-frame>

--- a/app/components/books/b_note_component.rb
+++ b/app/components/books/b_note_component.rb
@@ -2,9 +2,10 @@
 
 module Books
   class BNoteComponent < ViewComponent::Base
-    def initialize(books:, pagy:)
+    def initialize(books:, pagy:, next_page_path: nil)
       @books = books
       @pagy = pagy
+      @next_page_path = next_page_path
     end
   end
 end

--- a/app/components/books/card_grid_component.html.erb
+++ b/app/components/books/card_grid_component.html.erb
@@ -21,7 +21,7 @@
 
 
 <% if @pagy && @pagy.next %>
-  <turbo-frame id="next_books" src="<%= helpers.books_index_path(view: "card", page: @pagy.next) %>" loading="lazy">
+  <turbo-frame id="next_books" src="<%= @next_page_path || helpers.books_index_path(view: "card", page: @pagy.next) %>" loading="lazy">
     <%= render "shared/loading_spinner" %>
   </turbo-frame>
 <% end %>

--- a/app/components/books/card_grid_component.rb
+++ b/app/components/books/card_grid_component.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 class Books::CardGridComponent < ViewComponent::Base
-  def initialize(books:, card_columns:, pagy:)
+  def initialize(books:, card_columns:, pagy:, next_page_path: nil)
     @books = books
     @card_columns = card_columns
     @pagy = pagy
+    @next_page_path = next_page_path
   end
 
   def options

--- a/app/components/books/detail_card_component.html.erb
+++ b/app/components/books/detail_card_component.html.erb
@@ -28,7 +28,7 @@
 </div>
 
 <% if @pagy && @pagy.next %>
-  <turbo-frame id="next_books" src="<%= helpers.books_index_path(view: "detail_card", page: @pagy.next) %>" loading="lazy">
+  <turbo-frame id="next_books" src="<%= @next_page_path || helpers.books_index_path(view: "detail_card", page: @pagy.next) %>" loading="lazy">
     <%= render "shared/loading_spinner" %>
   </turbo-frame>
 <% end %>

--- a/app/components/books/detail_card_component.rb
+++ b/app/components/books/detail_card_component.rb
@@ -2,11 +2,12 @@
 
 module Books
   class DetailCardComponent < ViewComponent::Base
-    def initialize(books:, pagy:, detail_card_columns: nil, mobile: false)
+    def initialize(books:, pagy:, detail_card_columns: nil, mobile: false, next_page_path: nil)
       @books = books
       @pagy = pagy
       @detail_card_columns = detail_card_columns
       @mobile = mobile
+      @next_page_path = next_page_path
     end
 
     def options

--- a/app/components/books/kino_grid_component.html.erb
+++ b/app/components/books/kino_grid_component.html.erb
@@ -20,7 +20,7 @@
 <% end %>
 
 <% if @pagy && @pagy.next %>
-  <turbo-frame id="next_books" src="<%= helpers.books_index_path(view: "shelf", page: @pagy.next) %>" loading="lazy">
+  <turbo-frame id="next_books" src="<%= @next_page_path || helpers.books_index_path(view: "shelf", page: @pagy.next) %>" loading="lazy">
     <%= render "shared/loading_spinner" %>
   </turbo-frame>
 <% end %>

--- a/app/components/books/kino_grid_component.rb
+++ b/app/components/books/kino_grid_component.rb
@@ -2,10 +2,11 @@
 
 module Books
   class KinoGridComponent < ViewComponent::Base
-    def initialize(books:, books_per_shelf:, pagy: nil)
+    def initialize(books:, books_per_shelf:, pagy: nil, next_page_path: nil)
       @books = books
       @books_per_shelf = books_per_shelf
       @pagy = pagy
+      @next_page_path = next_page_path
     end
   end
 end

--- a/app/components/books/spine_grid_component.html.erb
+++ b/app/components/books/spine_grid_component.html.erb
@@ -36,7 +36,7 @@
 <% end %>
 
 <% if @pagy&.next %>
-  <turbo-frame id="next_books" src="<%= helpers.books_index_path(view: params[:view], page: @pagy.next) %>" loading="lazy">
+  <turbo-frame id="next_books" src="<%= @next_page_path || helpers.books_index_path(view: "spine", page: @pagy.next) %>" loading="lazy">
     <%= render "shared/loading_spinner" %>
   </turbo-frame>
 <% end %>

--- a/app/components/books/spine_grid_component.rb
+++ b/app/components/books/spine_grid_component.rb
@@ -3,9 +3,10 @@
 class Books::SpineGridComponent < ViewComponent::Base
   include ApplicationHelper
 
-  def initialize(books:, spine_per_shelf:, pagy: nil)
+  def initialize(books:, spine_per_shelf:, pagy: nil, next_page_path: nil)
     @books = books
     @spine_per_shelf = spine_per_shelf
     @pagy = pagy
+    @next_page_path = next_page_path
   end
 end

--- a/app/controllers/explore_controller.rb
+++ b/app/controllers/explore_controller.rb
@@ -23,17 +23,13 @@ class ExploreController < ApplicationController
       @spine_per_shelf     = presenter.spine_per_shelf
       @read_only           = presenter.read_only
 
-      books = current_user.books.includes(book_cover_s3_attachment: :blob)
+      books = user_books_for(current_user)
       books = BooksQuery.new(books, params: params, current_user: current_user).call
-
-      if @query.present?
-        title_author_ids = books.search_by_title_and_author(@query).pluck(:id)
-        memo_book_ids = current_user.memos.search_by_content(@query).pluck(:book_id)
-        books = books.where(id: (title_author_ids + memo_book_ids).uniq)
-      end
+      books = filter_by_query(books, current_user)
 
       books_per_page = (presenter.display.unit_per_page * 3).to_i
       @pagy, @books = pagy(books, items: books_per_page)
+      @next_page_path = next_page_path
 
     when "guest"
       presenter = BooksIndexPresenter.new(
@@ -51,17 +47,13 @@ class ExploreController < ApplicationController
       @spine_per_shelf     = presenter.spine_per_shelf
       @read_only           = true
 
-      books = guest_user.books.includes(book_cover_s3_attachment: :blob)
+      books = user_books_for(guest_user)
       books = BooksQuery.new(books, params: params, current_user: guest_user).call
-
-      if @query.present?
-        title_author_ids = books.search_by_title_and_author(@query).pluck(:id)
-        memo_book_ids = guest_user.memos.search_by_content(@query).pluck(:book_id)
-        books = books.where(id: (title_author_ids + memo_book_ids).uniq)
-      end
+      books = filter_by_query(books, guest_user)
 
       books_per_page = (presenter.display.unit_per_page * 3).to_i
       @pagy, @books = pagy(books, items: books_per_page)
+      @next_page_path = next_page_path
 
     end
 
@@ -75,8 +67,12 @@ class ExploreController < ApplicationController
   private
 
   def turbo_render_partial!
-    case @scope
-    when "mine", "guest"
+    return unless %w[mine guest].include?(@scope)
+
+    case request.headers["Turbo-Frame"]
+    when "next_books"
+      render_chunk_for(@view_mode)
+    else
       render turbo_stream: turbo_stream.update(
         "books_frame",
         partial: "bookshelf/books_frame_wrapper",
@@ -87,9 +83,52 @@ class ExploreController < ApplicationController
           books_per_shelf: @books_per_shelf,
           card_columns: @card_columns,
           detail_card_columns: @detail_card_columns,
-          spine_per_shelf: @spine_per_shelf
+          spine_per_shelf: @spine_per_shelf,
+          next_page_path: @next_page_path
         }
       )
     end
+  end
+
+  def render_chunk_for(view_mode)
+    case view_mode
+    when "shelf"
+      render partial: "bookshelf/kino_chunk",
+            locals: { books: @books, books_per_shelf: @books_per_shelf, pagy: @pagy, next_page_path: @next_page_path }
+    when "spine"
+      render partial: "bookshelf/spine_chunk",
+            locals: { books: @books, spine_per_shelf: @spine_per_shelf, pagy: @pagy, next_page_path: @next_page_path }
+    when "card"
+      render partial: "bookshelf/card_chunk",
+            locals: { books: @books, pagy: @pagy, card_columns: @card_columns, next_page_path: @next_page_path }
+    when "detail_card"
+      render partial: "bookshelf/detail_card_chunk",
+            locals: { books: @books, pagy: @pagy, detail_card_columns: @detail_card_columns, next_page_path: @next_page_path }
+    when "b_note"
+      render partial: "bookshelf/b_chunk",
+            locals: { books: @books, pagy: @pagy, next_page_path: @next_page_path }
+    end
+  end
+
+  def next_page_path
+    return unless @pagy&.next
+
+    explore_path(request.query_parameters.merge(page: @pagy.next, view: @view_mode))
+  end
+
+  def user_books_for(user)
+    if @view_mode == "b_note"
+      user.books.select(:id, :title, :author, :publisher)
+    else
+      user.books.includes(book_cover_s3_attachment: :blob)
+    end
+  end
+
+  def filter_by_query(books, user)
+    return books if @query.blank?
+
+    title_author_ids = books.fuzzy_title_or_author(@query).pluck(:id)
+    memo_book_ids = user.memos.search_by_content(@query).pluck(:book_id)
+    books.where(id: (title_author_ids + memo_book_ids).uniq)
   end
 end

--- a/app/frontend/entrypoints/controllers/autocomplete_controller.ts
+++ b/app/frontend/entrypoints/controllers/autocomplete_controller.ts
@@ -16,10 +16,17 @@ export default class AutocompleteController extends Controller {
   declare readonly suggestionsTarget: HTMLElement
   declare readonly urlValue: string
 
-  private debounceTimer: number | null = null
+  private suggestionsTimer: number | null = null
+  private searchTimer: number | null = null
 
   connect(): void {
-    this.debounceTimer = null
+    this.suggestionsTimer = null
+    this.searchTimer = null
+  }
+
+  disconnect(): void {
+    if (this.suggestionsTimer) clearTimeout(this.suggestionsTimer)
+    if (this.searchTimer) clearTimeout(this.searchTimer)
   }
 
   fetchSuggestions(event: Event): void {
@@ -28,17 +35,22 @@ export default class AutocompleteController extends Controller {
 
     if (query.length < 1) {
       this.clearSuggestions()
+      this.scheduleBookshelfSearch()
       return
     }
 
-    if (this.debounceTimer) clearTimeout(this.debounceTimer)
+    this.scheduleBookshelfSearch()
 
-    this.debounceTimer = window.setTimeout(() => {
+    if (this.suggestionsTimer) clearTimeout(this.suggestionsTimer)
+
+    this.suggestionsTimer = window.setTimeout(() => {
       const url = `${this.urlValue}&term=${encodeURIComponent(query)}&_ts=${Date.now()}`
 
       fetch(url)
         .then((res) => res.json())
         .then((data: SuggestionItem[]) => {
+          if (this.inputTarget.value.trim() !== query) return
+
           this.showSuggestions(data)
         })
         .catch((error) => console.error("Autocomplete error:", error))
@@ -54,13 +66,18 @@ export default class AutocompleteController extends Controller {
 
       const a = document.createElement("a")
       a.className = "d-block px-3 py-2 text-decoration-none text-black-50"
-      a.innerHTML = item.label || item.value || "（無題）"
+      a.textContent = item.label || item.value || "（無題）"
       a.href = item.url || "#"
 
       li.addEventListener("mousedown", (e) => {
         e.preventDefault()
         this.inputTarget.value = item.value || ""
         this.clearSuggestions()
+        this.submitBookshelfSearch()
+      })
+
+      a.addEventListener("click", (e) => {
+        e.preventDefault()
       })
 
       li.appendChild(a)
@@ -70,5 +87,25 @@ export default class AutocompleteController extends Controller {
 
   clearSuggestions(): void {
     this.suggestionsTarget.innerHTML = ""
+  }
+
+  private scheduleBookshelfSearch(): void {
+    if (this.searchTimer) clearTimeout(this.searchTimer)
+
+    this.searchTimer = window.setTimeout(() => {
+      this.submitBookshelfSearch()
+    }, 200)
+  }
+
+  private submitBookshelfSearch(): void {
+    if (this.searchTimer) {
+      clearTimeout(this.searchTimer)
+      this.searchTimer = null
+    }
+
+    const form = this.element.closest("form")
+    if (form instanceof HTMLFormElement) {
+      form.requestSubmit()
+    }
   }
 }

--- a/app/presenters/bookshelf_layout_config.rb
+++ b/app/presenters/bookshelf_layout_config.rb
@@ -6,6 +6,7 @@ class BookshelfLayoutConfig
   CARD_COLUMNS_KEY        = :card_columns
   DETAIL_CARD_COLUMNS_KEY = :detail_card_columns
   SPINE_PER_KEY           = :spine_per
+  VALID_VIEW_MODES        = %w[shelf spine card detail_card b_note].freeze
 
   attr_reader :view_mode, :unit_per_page, :books_per_shelf,
               :card_columns, :detail_card_columns, :spine_per_shelf
@@ -23,6 +24,10 @@ class BookshelfLayoutConfig
   private
 
   def configure_view_mode
+    if @params[:view].present? && VALID_VIEW_MODES.include?(@params[:view])
+      @session[VIEW_MODE_KEY] = @params[:view]
+    end
+
     @view_mode = @session[VIEW_MODE_KEY].presence || "shelf"
   end
 

--- a/app/views/bookshelf/_b_chunk.html.erb
+++ b/app/views/bookshelf/_b_chunk.html.erb
@@ -1,5 +1,4 @@
 <!-- 無限スクロール用 -->
 <turbo-frame id="next_books">
-  <%= render Books::BNoteComponent.new(books: books, pagy: pagy) %>
+  <%= render Books::BNoteComponent.new(books: books, pagy: pagy, next_page_path: local_assigns[:next_page_path]) %>
 </turbo-frame>
-

--- a/app/views/bookshelf/_books_frame_wrapper.html.erb
+++ b/app/views/bookshelf/_books_frame_wrapper.html.erb
@@ -1,4 +1,6 @@
 <turbo-frame id="books_frame">
+  <% next_page_path = local_assigns[:next_page_path] %>
+
   <% case view_mode %>
   <% when "shelf" %>
     <%= render Books::KinoSelectNumbersComponent.new(
@@ -6,7 +8,7 @@
           selected: books_per_shelf,
           mobile: mobile?
         ) %>
-    <%= render Books::KinoGridComponent.new(books: books, books_per_shelf: books_per_shelf, pagy: pagy) %>
+    <%= render Books::KinoGridComponent.new(books: books, books_per_shelf: books_per_shelf, pagy: pagy, next_page_path: next_page_path) %>
 
   <% when "spine" %>
     <%= render Books::KinoSelectNumbersComponent.new(
@@ -14,7 +16,7 @@
           selected: spine_per_shelf,
           mobile: mobile?
         ) %>
-    <%= render Books::SpineGridComponent.new(books: books, spine_per_shelf: spine_per_shelf, pagy: pagy) %>
+    <%= render Books::SpineGridComponent.new(books: books, spine_per_shelf: spine_per_shelf, pagy: pagy, next_page_path: next_page_path) %>
 
   <% when "card" %>
     <%= render Books::ColumnSelectorComponent.new(
@@ -23,7 +25,7 @@
           controller_name: "column-selector",
           mobile: mobile?
         ) %>
-    <%= render Books::CardGridComponent.new(books: books, card_columns: card_columns, pagy: pagy) %>
+    <%= render Books::CardGridComponent.new(books: books, card_columns: card_columns, pagy: pagy, next_page_path: next_page_path) %>
 
   <% when "detail_card" %>
     <%= render Books::ColumnSelectorComponent.new(
@@ -32,10 +34,9 @@
           controller_name: "detail-card-column-selector",
           mobile: mobile?
         ) %>
-    <%= render Books::DetailCardComponent.new(books: books, pagy: pagy, detail_card_columns: detail_card_columns) %>
+    <%= render Books::DetailCardComponent.new(books: books, pagy: pagy, detail_card_columns: detail_card_columns, next_page_path: next_page_path) %>
 
   <% when "b_note" %>
-    <%= render Books::BNoteComponent.new(books: books, pagy: pagy) %>
+    <%= render Books::BNoteComponent.new(books: books, pagy: pagy, next_page_path: next_page_path) %>
   <% end %>
 </turbo-frame>
-

--- a/app/views/bookshelf/_card_chunk.html.erb
+++ b/app/views/bookshelf/_card_chunk.html.erb
@@ -3,5 +3,6 @@
     <%= render Books::CardGridComponent.new(
       books: books,
       card_columns: card_columns,
-      pagy: pagy) %>
+      pagy: pagy,
+      next_page_path: local_assigns[:next_page_path]) %>
 </turbo-frame>

--- a/app/views/bookshelf/_detail_card_chunk.html.erb
+++ b/app/views/bookshelf/_detail_card_chunk.html.erb
@@ -3,5 +3,6 @@
     <%= render Books::DetailCardComponent.new(
       books: books,
       detail_card_columns: detail_card_columns,
-      pagy: pagy) %>
+      pagy: pagy,
+      next_page_path: local_assigns[:next_page_path]) %>
 </turbo-frame>

--- a/app/views/bookshelf/_kino_chunk.html.erb
+++ b/app/views/bookshelf/_kino_chunk.html.erb
@@ -3,6 +3,7 @@
   <%= render Books::KinoGridComponent.new(
       books: books,
       books_per_shelf: books_per_shelf,
-      pagy: pagy
+      pagy: pagy,
+      next_page_path: local_assigns[:next_page_path]
     ) %>
 </turbo-frame>

--- a/app/views/bookshelf/_spine_chunk.html.erb
+++ b/app/views/bookshelf/_spine_chunk.html.erb
@@ -1,6 +1,6 @@
 <!-- 無限スクロール用 -->
 <turbo-frame id="next_books">
   <%= render Books::SpineGridComponent.new(
-    books: books, spine_per_shelf: spine_per_shelf, pagy: pagy
+    books: books, spine_per_shelf: spine_per_shelf, pagy: pagy, next_page_path: local_assigns[:next_page_path]
   ) %>
 </turbo-frame>

--- a/spec/requests/explore_spec.rb
+++ b/spec/requests/explore_spec.rb
@@ -48,5 +48,70 @@ RSpec.describe "Explore", type: :request do
       expect(response.media_type).to eq("text/vnd.turbo-stream.html")
       expect(response.body).to include("Turbo本")
     end
+
+    it "タイトルの途中一致で自分の本棚を検索できる" do
+      matching_book = create(:book, title: "実践Ruby設計", user: user)
+      create(:book, title: "Python設計", user: user)
+
+      get explore_path(q: "Ruby", scope: "mine"), headers: { "Turbo-Frame" => "books_frame" }
+
+      expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+      expect(response.body).to include(matching_book.title)
+      expect(response.body).not_to include("Python設計")
+    end
+
+    it "著者の途中一致で自分の本棚を検索できる" do
+      matching_book = create(:book, title: "文豪の本", author: "夏目漱石", user: user)
+      create(:book, title: "別の本", author: "芥川龍之介", user: user)
+
+      get explore_path(q: "漱石", scope: "mine"), headers: { "Turbo-Frame" => "books_frame" }
+
+      expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+      expect(response.body).to include(matching_book.title)
+      expect(response.body).not_to include("別の本")
+    end
+
+    it "空クエリで自分の本棚一覧を返す" do
+      other_book = create(:book, title: "別の本", user: user)
+
+      get explore_path(q: "", scope: "mine"), headers: { "Turbo-Frame" => "books_frame" }
+
+      expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+      expect(response.body).to include(@book.title)
+      expect(response.body).to include(other_book.title)
+    end
+
+    it "サンプル本棚もTurbo Streamで検索できる" do
+      guest = ensure_guest_user
+      create(:book, title: "ゲストTurbo本", author: "ゲスト著者", user: guest)
+
+      get explore_path(q: "ゲストTurbo", scope: "guest"), headers: { "Turbo-Frame" => "books_frame" }
+
+      expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+      expect(response.body).to include("ゲストTurbo本")
+    end
+
+    it "検索結果のnext_books URLに検索条件を保持する" do
+      create_list(:book, 70, title: "Turbo検索本", user: user)
+
+      get explore_path(q: "Turbo検索", scope: "mine", view: "shelf"), headers: { "Turbo-Frame" => "books_frame" }
+
+      expect(response.body).to include("src=\"/explore?")
+      expect(response.body).to include("q=Turbo")
+      expect(response.body).to include("scope=mine")
+      expect(response.body).to include("view=shelf")
+    end
+
+    it "next_booksリクエストで現在の表示モードのchunkを返す" do
+      create_list(:book, 70, title: "Turboページ本", user: user)
+
+      %w[shelf spine card detail_card b_note].each do |view_mode|
+        get explore_path(q: "Turboページ", scope: "mine", view: view_mode, page: 2), headers: { "Turbo-Frame" => "next_books" }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.media_type).to eq("text/html")
+        expect(response.body).to include('turbo-frame id="next_books"')
+      end
+    end
   end
 end

--- a/spec/services/book_autocomplete_service_spec.rb
+++ b/spec/services/book_autocomplete_service_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe BookAutocompleteService do
+  let(:user) { create(:user) }
+
+  describe "#call" do
+    it "タイトルに一致する自分の本を候補として返す" do
+      create(:book, title: "Ruby入門", author: "山田", user: user)
+      create(:book, title: "Python入門", author: "佐藤", user: user)
+
+      results = described_class.new(term: "Ruby", scope: "mine", user: user).call
+
+      expect(results).to contain_exactly(
+        include(value: "Ruby入門", label: "Ruby入門（山田）")
+      )
+    end
+
+    it "著者に一致するサンプル本を候補として返す" do
+      create(:book, title: "ゲストの本", author: "夏目漱石", user: user)
+
+      results = described_class.new(term: "漱石", scope: "guest", user: user).call
+
+      expect(results).to contain_exactly(
+        include(value: "ゲストの本", label: "ゲストの本（夏目漱石）")
+      )
+    end
+
+    it "未対応scopeでは候補を返さない" do
+      create(:book, title: "Ruby入門", user: user)
+
+      results = described_class.new(term: "Ruby", scope: "public", user: user).call
+
+      expect(results).to eq([])
+    end
+  end
+end


### PR DESCRIPTION
## 概要

books#index の本棚検索で、オートコンプリート入力に合わせて本棚表示を非同期更新するようにしました。

これまでは候補表示だけが更新され、検索ボタンを押すまで本棚側は変わりませんでした。今回の変更で、入力中および候補選択時に `books_frame` が更新され、現在の本棚表示モードに合ったレイアウトで検索結果が表示されます。

## 変更内容

- オートコンプリート入力時に本棚検索フォームを debounce 送信
- 候補選択時に即時で本棚を非同期更新
- 候補ラベル描画を `innerHTML` から `textContent` に変更
- `explore` の Turbo 応答で `books_frame` と `next_books` を整理
- 検索結果の無限スクロールで `q / scope / view` などの検索条件を保持
- 5つの本棚表示モードに `next_page_path` を渡せるように変更
  - `shelf`
  - `spine`
  - `card`
  - `detail_card`
  - `b_note`
- タイトル・著者検索をオートコンプリートと同じ途中一致に統一
- `b_note` では不要な表紙 attachment eager load を避けるよう調整
- request spec / service spec を追加

## 確認したこと

```sh
/usr/local/bin/docker compose run --rm -e SKIP_TEST_PREPARE=1 web-test bundle exec rspec spec/requests/explore_spec.rb spec/services/book_autocomplete_service_spec.rb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 無限スクロール時の次ページ遷移ナビゲーションが正しく機能するよう改善
  * ビューモード切り替え時に検索条件が適切に保持されるよう修正

* **Improvements**
  * 検索入力のデバウンス処理を最適化
  * ビューモード検証ロジックを強化

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Peeaaaa-art/Bokrium/pull/462?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->