### PR TITLE
books#show に OGP プレビューと SVG デフォルト書影を追加

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -1,8 +1,9 @@
 class BooksController < ApplicationController
-  before_action :authenticate_user!, only: %i[ index create show edit update destroy ]
+  before_action :authenticate_user!, only: %i[ index create edit update destroy ]
   before_action :set_book, only: %i[ edit update destroy ]
   before_action :set_book_with_associations, only: [ :show ]
-  before_action :set_user_tags, only: %i[ show ]
+  before_action :set_og_image_book, only: [ :og_image ]
+  before_action :set_user_tags, only: %i[ show ], if: :user_signed_in?
 
   def index
     unless current_user.books.exists?
@@ -43,9 +44,20 @@ class BooksController < ApplicationController
   end
 
   def show
+    unless user_signed_in?
+      render :og_preview and return
+    end
+
     @memos = @book.memos.order(created_at: :desc)
     @new_memo = @book.memos.new(user_id: current_user.id)
     @user_tag = UserTag.new
+  end
+
+  def og_image
+    expires_in 1.day, public: true
+    send_data BookOgImageSvg.new(@book).call,
+              type: "image/svg+xml; charset=utf-8",
+              disposition: "inline"
   end
 
   def new
@@ -130,9 +142,15 @@ class BooksController < ApplicationController
   end
 
   def set_book_with_associations
-    @book = current_user.books
+    scope = user_signed_in? ? current_user.books : Book.all
+
+    @book = scope
             .includes(:user_tags, { images: :image_s3_attachment }, :book_cover_s3_attachment)
             .find(params[:id])
+  end
+
+  def set_og_image_book
+    @book = Book.find(params[:id])
   end
 
   def set_user_tags

--- a/app/services/book_og_image_svg.rb
+++ b/app/services/book_og_image_svg.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+class BookOgImageSvg
+  WIDTH = 1200
+  HEIGHT = 630
+  COVER_WIDTH = 330
+  COVER_HEIGHT = 500
+  COVER_X = (WIDTH - COVER_WIDTH) / 2
+  COVER_Y = 64
+  BAND_HEIGHT = 52
+  MAX_LINES = 8
+
+  def initialize(book)
+    @book = book
+  end
+
+  def call
+    <<~SVG
+      <svg xmlns="http://www.w3.org/2000/svg" width="#{WIDTH}" height="#{HEIGHT}" viewBox="0 0 #{WIDTH} #{HEIGHT}" role="img" aria-label="#{escape(title)}">
+        <rect width="#{WIDTH}" height="#{HEIGHT}" fill="#f7f1df"/>
+        <rect x="#{COVER_X - 26}" y="#{COVER_Y - 24}" width="#{COVER_WIDTH + 52}" height="#{COVER_HEIGHT + 48}" rx="28" fill="#000" opacity="0.08"/>
+        <g filter="url(#shadow)">
+          <rect x="#{COVER_X}" y="#{COVER_Y}" width="#{COVER_WIDTH}" height="#{COVER_HEIGHT}" rx="8" fill="#f1c94b"/>
+          #{title_lines_svg}
+          <rect x="#{COVER_X}" y="#{COVER_Y + COVER_HEIGHT - BAND_HEIGHT}" width="#{COVER_WIDTH}" height="#{BAND_HEIGHT}" rx="8" fill="#333333"/>
+          <rect x="#{COVER_X}" y="#{COVER_Y + COVER_HEIGHT - BAND_HEIGHT}" width="#{COVER_WIDTH}" height="8" fill="#333333"/>
+          <text x="#{COVER_X + COVER_WIDTH - 22}" y="#{COVER_Y + COVER_HEIGHT - 18}" text-anchor="end" font-family="Arial, 'Noto Sans JP', sans-serif" font-size="25" font-weight="700" fill="#ffffff" letter-spacing="1.2">Bokrium</text>
+        </g>
+        <defs>
+          <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+            <feDropShadow dx="0" dy="18" stdDeviation="16" flood-color="#000000" flood-opacity="0.24"/>
+          </filter>
+        </defs>
+      </svg>
+    SVG
+  end
+
+  private
+
+  attr_reader :book
+
+  def title
+    book.title.presence || "無題の本"
+  end
+
+  def title_lines_svg
+    lines = wrapped_title_lines
+    line_height = lines.size >= 7 ? 34 : 40
+    font_size = lines.size >= 7 ? 27 : 31
+    total_height = (lines.size - 1) * line_height
+    content_top = COVER_Y + 44
+    content_bottom = COVER_Y + COVER_HEIGHT - BAND_HEIGHT - 34
+    start_y = content_top + ((content_bottom - content_top - total_height) / 2)
+
+    lines.each_with_index.map do |line, index|
+      %(<text x="#{COVER_X + COVER_WIDTH / 2}" y="#{start_y + (index * line_height)}" text-anchor="middle" font-family="'Noto Sans JP', Arial, sans-serif" font-size="#{font_size}" font-weight="700" fill="#111111">#{escape(line)}</text>)
+    end.join("\n          ")
+  end
+
+  def wrapped_title_lines
+    lines = []
+    current = ""
+    current_width = 0.0
+    max_width = 8.8
+
+    title.each_char do |char|
+      char_width = char.ascii_only? ? 0.55 : 1.0
+
+      if current_width.positive? && current_width + char_width > max_width
+        lines << current
+        current = ""
+        current_width = 0.0
+        break if lines.size == MAX_LINES
+      end
+
+      current << char
+      current_width += char_width
+    end
+
+    lines << current if current.present? && lines.size < MAX_LINES
+
+    if lines.size == MAX_LINES && lines.join.length < title.length
+      lines[-1] = "#{lines[-1].chars[0...-1].join}…"
+    end
+
+    lines
+  end
+
+  def escape(value)
+    ERB::Util.html_escape(value)
+  end
+end

--- a/app/views/books/_og_meta.html.erb
+++ b/app/views/books/_og_meta.html.erb
@@ -1,0 +1,11 @@
+<% book_title = @book.title.presence || "無題の本" %>
+<% book_description = [@book.author.presence, @book.publisher.presence].compact.join(" / ").presence || "Bokriumに保存した読書メモの本です。" %>
+
+<% content_for :title, "#{book_title} - Bokrium" %>
+<% content_for :og_title, book_title %>
+<% content_for :og_description, book_description %>
+<% content_for :og_image, og_image_book_url(@book, format: :svg) %>
+<% content_for :og_image_type, "image/svg+xml" %>
+<% content_for :og_image_width, BookOgImageSvg::WIDTH.to_s %>
+<% content_for :og_image_height, BookOgImageSvg::HEIGHT.to_s %>
+<% content_for :og_type, "article" %>

--- a/app/views/books/og_preview.html.erb
+++ b/app/views/books/og_preview.html.erb
@@ -1,0 +1,23 @@
+<%= render "books/og_meta" %>
+
+<div class="container my-5" style="max-width: 720px;">
+  <div class="card border-0 shadow-sm">
+    <div class="card-body p-4 text-center">
+      <div class="mx-auto mb-4" style="max-width: 220px;">
+        <%= render Books::CoverComponent.new(
+          book: @book,
+          image_class: "book-cover-show",
+          truncate_options: { mobile_limit: 80, desktop_limit: 100 }
+        ) %>
+      </div>
+
+      <h1 class="h4 fw-bold mb-2"><%= @book.title %></h1>
+      <% if @book.author.present? %>
+        <p class="text-secondary mb-4"><%= @book.author %></p>
+      <% end %>
+
+      <p class="text-secondary mb-4">この本の読書メモを見るにはログインしてください。</p>
+      <%= link_to "ログイン", new_user_session_path, class: "btn btn-primary rounded-pill px-4" %>
+    </div>
+  </div>
+</div>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "読書メモ - Bokrium" %>
+<%= render "books/og_meta" %>
 
 <%= bookshelf_sample_notice %>
 <%= empty_bookshelf_notice %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,9 +6,21 @@
     <meta property="og:title" content="<%= content_for?(:og_title) ? yield(:og_title) : 'Bokrium - 読書メモアプリ' %>">
     <meta property="og:description" content="<%= content_for?(:og_description) ? yield(:og_description) : '「読んだだけ」で終わらせない。Bokriumは、読書の記憶を育てる本棚アプリです。' %>">
     <meta property="og:image" content="<%= content_for?(:og_image) ? yield(:og_image) : cdn_path("bokrium_ogp.png") %>">
+    <% if content_for?(:og_image_type) %>
+      <meta property="og:image:type" content="<%= yield(:og_image_type) %>">
+    <% end %>
+    <% if content_for?(:og_image_width) %>
+      <meta property="og:image:width" content="<%= yield(:og_image_width) %>">
+    <% end %>
+    <% if content_for?(:og_image_height) %>
+      <meta property="og:image:height" content="<%= yield(:og_image_height) %>">
+    <% end %>
     <meta property="og:url" content="<%= request.original_url %>">
-    <meta property="og:type" content="website">
+    <meta property="og:type" content="<%= content_for?(:og_type) ? yield(:og_type) : 'website' %>">
     <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="<%= content_for?(:og_title) ? yield(:og_title) : 'Bokrium - 読書メモアプリ' %>">
+    <meta name="twitter:description" content="<%= content_for?(:og_description) ? yield(:og_description) : '「読んだだけ」で終わらせない。Bokriumは、読書の記憶を育てる本棚アプリです。' %>">
+    <meta name="twitter:image" content="<%= content_for?(:og_image) ? yield(:og_image) : cdn_path("bokrium_ogp.png") %>">
 
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,10 @@ Rails.application.routes.draw do
   get "mypage", to: "users#show", as: :mypage
 
   resources :books do
+    member do
+      get :og_image, defaults: { format: :svg }
+    end
+
     resources :memos, only: [ :create, :new, :edit, :update, :destroy ]
     resources :images, only: [ :create, :destroy ]
     resource :row, only: [ :show, :edit, :update ], controller: "books/rows"

--- a/spec/requests/books_controller_spec.rb
+++ b/spec/requests/books_controller_spec.rb
@@ -53,9 +53,41 @@ RSpec.describe "BooksController", type: :request do
       expect(response.body).to include(book.title)
     end
 
+    it "books#show 用の OGP メタタグが表示されること" do
+      get book_path(book)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(%(property="og:title" content="#{book.title}"))
+      expect(response.body).to include(%(property="og:image" content="http://www.example.com/books/#{book.id}/og_image.svg"))
+      expect(response.body).to include(%(property="og:image:type" content="image/svg+xml"))
+      expect(response.body).to include(%(property="og:image:width" content="1200"))
+      expect(response.body).to include(%(property="og:image:height" content="630"))
+    end
+
     it "存在しないIDを指定した場合は本棚一覧にリダイレクトされること" do
       get book_path(id: 99999)
       expect(response.body).to include("404: Not Found")
+    end
+
+    context "when not signed in" do
+      before { sign_out user }
+
+      it "OGP を取得できるプレビューページが表示されること" do
+        get book_path(book)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(%(property="og:title" content="#{book.title}"))
+        expect(response.body).to include("この本の読書メモを見るにはログインしてください。")
+      end
+    end
+
+    it "Bokrium デフォルト書影の OGP 画像 SVG を返すこと" do
+      get og_image_book_path(book, format: :svg)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq("image/svg+xml")
+      expect(response.body).to include("Bokrium")
+      expect(response.body).to include(book.title)
     end
   end
 


### PR DESCRIPTION
### Motivation
- Apple のフリーボードなどに `books#show` の URL を貼ったときに適切なリンクプレビュー（OGP）が表示されるようにするため、書影がない場合は既存の Bokrium デフォルト書影デザインを流用した OGP 画像を生成する必要があった。
- リンクプレビュー取得は未ログイン状態で行われることがあるため、メモ本体を公開せずに OG メタ情報だけを提供する軽量なプレビューページを用意する目的がある。

### Description
- 追加した `BookOgImageSvg` サービスで Bokrium のデフォルト書影（黄色の表紙・黒い帯・タイトル表示）を 1200x630 の SVG として生成するようにした（`app/services/book_og_image_svg.rb`）。
- `books#og_image` アクションと member ルートを追加して `/books/:id/og_image.svg` で SVG を返すようにした（`config/routes.rb`, `app/controllers/books_controller.rb`）。
- 未ログイン時は本体のメモを出さない `og_preview` ビューを返すようにして、OGP 用メタ情報は共通 partial (`app/views/books/_og_meta.html.erb`) で供給するようにした（`app/views/books/og_preview.html.erb`, `app/views/books/show.html.erb` を調整）。
- レイアウトのメタを拡張して `og:image:type` / `og:image:width` / `og:image:height` と Twitter Card 用タグを追加し、リンクプレビューが画像情報を取得しやすくした（`app/views/layouts/application.html.erb`）。
- `spec/requests/books_controller_spec.rb` に OGP メタの出力、未ログインプレビュー表示、`og_image` の SVG レスポンスを検証するリクエストスペックを追加した。

### Testing
- `ruby -c app/controllers/books_controller.rb && ruby -c app/services/book_og_image_svg.rb && ruby -c config/routes.rb && ruby -c spec/requests/books_controller_spec.rb` を実行して構文チェックはすべて通過した（Syntax OK）。
- `docker compose run --rm web-test bundle exec rspec spec/requests/books_controller_spec.rb` はこの環境で `docker: command not found` のため実行できなかった（RSpec 実行は CI / ローカル Docker 環境で要実行）。
- スクリーンショット生成用に `tmp/screenshots/freeform-book-ogp-preview.png` を作成して表示イメージを用意したが、Playwright のブラウザ取得は外部ダウンロードで `403 Forbidden` により失敗したため自動キャプチャは行えなかった（ローカル／CI 環境での確認を推奨）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d744c29c0832ea321b837fc9d0920)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 書籍ページをSNSで共有する際に、タイトル・説明・動的生成されたプレビュー画像が正しく表示されるようになりました。
  * 未ログインユーザー向けにプレビューページを追加し、書籍情報を確認してからログインできるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->