### PR TITLE
Update default OGP image

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,7 @@
 
     <meta property="og:title" content="<%= content_for?(:og_title) ? yield(:og_title) : 'Bokrium - 読書メモアプリ' %>">
     <meta property="og:description" content="<%= content_for?(:og_description) ? yield(:og_description) : '「読んだだけ」で終わらせない。Bokriumは、読書の記憶を育てる本棚アプリです。' %>">
-    <meta property="og:image" content="<%= content_for?(:og_image) ? yield(:og_image) : cdn_path("bokrium_ogp.png") %>">
+    <meta property="og:image" content="<%= content_for?(:og_image) ? yield(:og_image) : "https://lib.bokrium.com/bokrium_ogp_meishi.png" %>">
     <meta property="og:url" content="<%= request.original_url %>">
     <meta property="og:type" content="website">
     <meta name="twitter:card" content="summary_large_image">

--- a/spec/requests/books_spec.rb
+++ b/spec/requests/books_spec.rb
@@ -20,6 +20,16 @@ RSpec.describe "Books", type: :request do
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("詳細テスト本")
     end
+
+    it "トップページと同じデフォルトOGPメタ情報が表示される" do
+      book = create(:book, user: user, title: "詳細テスト本")
+
+      get book_path(book)
+
+      expect(response.body).to include('property="og:title" content="Bokrium - 読書メモアプリ"')
+      expect(response.body).to include('property="og:description" content="「読んだだけ」で終わらせない。Bokriumは、読書の記憶を育てる本棚アプリです。"')
+      expect(response.body).to include('property="og:image" content="https://lib.bokrium.com/bokrium_ogp_meishi.png"')
+    end
   end
 
   describe "POST /books" do

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "Pages", type: :request do
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("Bokrium")
       expect(response.body).to include("読書の記憶を育てる本棚アプリ")
+      expect(response.body).to include('property="og:image" content="https://lib.bokrium.com/bokrium_ogp_meishi.png"')
     end
   end
 


### PR DESCRIPTION
## 概要

デフォルトのOGP画像を、新しい名刺デザインの画像に差し替えました。

## 変更内容

- アプリ全体のデフォルト `og:image` を `https://lib.bokrium.com/bokrium_ogp_meishi.png` に変更
- トップページで新しいOGP画像URLが出力されることをrequest specで確認
- `books#show` でもトップページと同じデフォルトOGP情報が出力されることをrequest specで確認

## 確認

- `docker compose run --rm -e SKIP_TEST_PREPARE=1 web-test bundle exec rspec spec/requests/pages_spec.rb spec/requests/books_spec.rb`
- push前フックで全RSpec通過
  - `271 examples, 0 failures, 2 pending`