### PR TITLE
Remove swipe-to-close behavior from memo modal

### DIFF
--- a/app/frontend/entrypoints/controllers/modal_swipe_controller.ts
+++ b/app/frontend/entrypoints/controllers/modal_swipe_controller.ts
@@ -4,14 +4,9 @@ export default class ModalSwipeController extends Controller<HTMLElement> {
   static targets = ["modal"]
   declare readonly modalTarget: HTMLElement
 
-  private startY: number | null = null
-  private threshold = 250
   private skipNextConfirmation = false
-  private shouldShowConfirmOnClose = false
 
   connect() {
-    this.modalTarget.addEventListener("touchstart", this.onTouchStart)
-    this.modalTarget.addEventListener("touchend", this.onTouchEnd)
     this.modalTarget.addEventListener("hidden.bs.modal", this.onModalHidden)
     this.modalTarget.addEventListener("shown.bs.modal", () => {
       this.skipNextConfirmation = false
@@ -19,31 +14,11 @@ export default class ModalSwipeController extends Controller<HTMLElement> {
   }
 
   disconnect() {
-    this.modalTarget.removeEventListener("touchstart", this.onTouchStart)
-    this.modalTarget.removeEventListener("touchend", this.onTouchEnd)
     this.modalTarget.removeEventListener("hidden.bs.modal", this.onModalHidden)
   }
 
   skipConfirmationOnce() {
     this.skipNextConfirmation = true
-  }
-
-  private onTouchStart = (e: TouchEvent) => {
-    this.startY = e.touches[0]?.clientY ?? null
-  }
-
-  private onTouchEnd = (e: TouchEvent) => {
-    const endY = e.changedTouches[0]?.clientY ?? 0
-    const deltaY = this.startY !== null ? endY - this.startY : 0
-
-    if (Math.abs(deltaY) > this.threshold) {
-      if (window.hasUnsavedChanges) {
-        this.shouldShowConfirmOnClose = true
-      }
-      (window as any).bootstrap.Modal.getInstance(this.modalTarget)?.hide()
-    }
-
-    this.startY = null
   }
 
   private onModalHidden = () => {
@@ -52,8 +27,7 @@ export default class ModalSwipeController extends Controller<HTMLElement> {
       return
     }
 
-    if (window.hasUnsavedChanges || this.shouldShowConfirmOnClose) {
-      this.shouldShowConfirmOnClose = false
+    if (window.hasUnsavedChanges) {
       const confirmModalEl = document.getElementById("confirmModal")
       if (confirmModalEl) {
         const confirm = new (window as any).bootstrap.Modal(confirmModalEl)


### PR DESCRIPTION
### Motivation
- The memo edit modal was being dismissed when a user swiped/dragged inside it, which caused accidental closes while scrolling; the swipe-to-close behavior should be removed so scrolling is treated as normal scrolling.

### Description
- Removed touch tracking and swipe-to-close logic from `app/frontend/entrypoints/controllers/modal_swipe_controller.ts` by deleting `touchstart`/`touchend` listeners and the related handlers and threshold variables.
- Removed the `shouldShowConfirmOnClose` code path so modal closing logic only shows the unsaved-changes confirmation when `window.hasUnsavedChanges` is true.
- Left regular modal lifecycle hooks (`hidden.bs.modal` / `shown.bs.modal`) and the confirmation modal behavior intact.

### Testing
- Ran `npm run build` (Vite) and the JS/CSS build completed successfully with existing Sass deprecation warnings but no build failure. 
- Ran `git diff --check` with no reported problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a243aac4c98832e94398df7d2784b33)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * モーダルクローズ時の確認ダイアログ表示ロジックを簡素化。保存されていない変更がある場合のみ確認ダイアログが表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->