### PR TITLE
Simplify modal swipe controller and fix bootstrap Modal typing

### DIFF
--- a/app/frontend/entrypoints/controllers/modal_swipe_controller.ts
+++ b/app/frontend/entrypoints/controllers/modal_swipe_controller.ts
@@ -4,46 +4,24 @@ export default class ModalSwipeController extends Controller<HTMLElement> {
   static targets = ["modal"]
   declare readonly modalTarget: HTMLElement
 
-  private startY: number | null = null
-  private threshold = 250
   private skipNextConfirmation = false
-  private shouldShowConfirmOnClose = false
 
   connect() {
-    this.modalTarget.addEventListener("touchstart", this.onTouchStart)
-    this.modalTarget.addEventListener("touchend", this.onTouchEnd)
     this.modalTarget.addEventListener("hidden.bs.modal", this.onModalHidden)
-    this.modalTarget.addEventListener("shown.bs.modal", () => {
-      this.skipNextConfirmation = false
-    })
+    this.modalTarget.addEventListener("shown.bs.modal", this.onModalShown)
   }
 
   disconnect() {
-    this.modalTarget.removeEventListener("touchstart", this.onTouchStart)
-    this.modalTarget.removeEventListener("touchend", this.onTouchEnd)
     this.modalTarget.removeEventListener("hidden.bs.modal", this.onModalHidden)
+    this.modalTarget.removeEventListener("shown.bs.modal", this.onModalShown)
   }
 
   skipConfirmationOnce() {
     this.skipNextConfirmation = true
   }
 
-  private onTouchStart = (e: TouchEvent) => {
-    this.startY = e.touches[0]?.clientY ?? null
-  }
-
-  private onTouchEnd = (e: TouchEvent) => {
-    const endY = e.changedTouches[0]?.clientY ?? 0
-    const deltaY = this.startY !== null ? endY - this.startY : 0
-
-    if (Math.abs(deltaY) > this.threshold) {
-      if (window.hasUnsavedChanges) {
-        this.shouldShowConfirmOnClose = true
-      }
-      (window as any).bootstrap.Modal.getInstance(this.modalTarget)?.hide()
-    }
-
-    this.startY = null
+  private onModalShown = () => {
+    this.skipNextConfirmation = false
   }
 
   private onModalHidden = () => {
@@ -52,11 +30,10 @@ export default class ModalSwipeController extends Controller<HTMLElement> {
       return
     }
 
-    if (window.hasUnsavedChanges || this.shouldShowConfirmOnClose) {
-      this.shouldShowConfirmOnClose = false
+    if (window.hasUnsavedChanges) {
       const confirmModalEl = document.getElementById("confirmModal")
       if (confirmModalEl) {
-        const confirm = new (window as any).bootstrap.Modal(confirmModalEl)
+        const confirm = new window.bootstrap.Modal(confirmModalEl)
         confirm.show()
       }
     }


### PR DESCRIPTION
### Motivation
- Remove fragile touch swipe-to-close behavior and streamline modal close confirmation flow. 
- Ensure `skipNextConfirmation` is consistently reset when a modal is shown. 
- Use a properly typed reference to Bootstrap's `Modal` constructor rather than a loose `any` cast. 

### Description
- Removed touch handling logic and related state (`startY`, `threshold`, and `shouldShowConfirmOnClose`) and the `touchstart`/`touchend` listeners. 
- Added an `onModalShown` handler to reset `skipNextConfirmation` and wired it to the `shown.bs.modal` event on connect/disconnect. 
- Simplified `onModalHidden` to only show the confirm modal when `window.hasUnsavedChanges` is true and to respect `skipNextConfirmation`. 
- Replaced the casted `new (window as any).bootstrap.Modal(...)` with `new window.bootstrap.Modal(...)` for clearer typing. 

### Testing
- Ran TypeScript build (`yarn build`) and the code compiles successfully. 
- Ran the frontend test suite (`yarn test`) and all tests passed. 
- Ran linting (`yarn lint`) with no new warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a243aac4c98832e94398df7d2784b33)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * モーダル閉じる際の未保存変更の確認ダイアログが、より確実に表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->