### PR TITLE
Simplify modal swipe controller and fix bootstrap Modal typing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby "~> 4.0.1"
 
 gem "rails", "~> 8.1.2"
 
-gem "puma"
+gem "puma", "~> 8.0", ">= 8.0.2"
 
 gem "turbo-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -341,7 +341,7 @@ GEM
       date
       stringio
     public_suffix (7.0.5)
-    puma (7.2.0)
+    puma (8.0.2)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.6)
@@ -575,7 +575,7 @@ DEPENDENCIES
   pg
   pg_search
   propshaft
-  puma
+  puma (~> 8.0, >= 8.0.2)
   rack-mini-profiler
   rack-rewrite
   rails (~> 8.1.2)

--- a/app/frontend/entrypoints/controllers/modal_swipe_controller.ts
+++ b/app/frontend/entrypoints/controllers/modal_swipe_controller.ts
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { Modal } from "bootstrap"
 
 export default class ModalSwipeController extends Controller<HTMLElement> {
   static targets = ["modal"]
@@ -33,7 +34,7 @@ export default class ModalSwipeController extends Controller<HTMLElement> {
     if (window.hasUnsavedChanges) {
       const confirmModalEl = document.getElementById("confirmModal")
       if (confirmModalEl) {
-        const confirm = new window.bootstrap.Modal(confirmModalEl)
+        const confirm = Modal.getOrCreateInstance(confirmModalEl)
         confirm.show()
       }
     }

--- a/app/frontend/entrypoints/controllers/modal_swipe_controller.ts
+++ b/app/frontend/entrypoints/controllers/modal_swipe_controller.ts
@@ -4,46 +4,24 @@ export default class ModalSwipeController extends Controller<HTMLElement> {
   static targets = ["modal"]
   declare readonly modalTarget: HTMLElement
 
-  private startY: number | null = null
-  private threshold = 250
   private skipNextConfirmation = false
-  private shouldShowConfirmOnClose = false
 
   connect() {
-    this.modalTarget.addEventListener("touchstart", this.onTouchStart)
-    this.modalTarget.addEventListener("touchend", this.onTouchEnd)
     this.modalTarget.addEventListener("hidden.bs.modal", this.onModalHidden)
-    this.modalTarget.addEventListener("shown.bs.modal", () => {
-      this.skipNextConfirmation = false
-    })
+    this.modalTarget.addEventListener("shown.bs.modal", this.onModalShown)
   }
 
   disconnect() {
-    this.modalTarget.removeEventListener("touchstart", this.onTouchStart)
-    this.modalTarget.removeEventListener("touchend", this.onTouchEnd)
     this.modalTarget.removeEventListener("hidden.bs.modal", this.onModalHidden)
+    this.modalTarget.removeEventListener("shown.bs.modal", this.onModalShown)
   }
 
   skipConfirmationOnce() {
     this.skipNextConfirmation = true
   }
 
-  private onTouchStart = (e: TouchEvent) => {
-    this.startY = e.touches[0]?.clientY ?? null
-  }
-
-  private onTouchEnd = (e: TouchEvent) => {
-    const endY = e.changedTouches[0]?.clientY ?? 0
-    const deltaY = this.startY !== null ? endY - this.startY : 0
-
-    if (Math.abs(deltaY) > this.threshold) {
-      if (window.hasUnsavedChanges) {
-        this.shouldShowConfirmOnClose = true
-      }
-      (window as any).bootstrap.Modal.getInstance(this.modalTarget)?.hide()
-    }
-
-    this.startY = null
+  private onModalShown = () => {
+    this.skipNextConfirmation = false
   }
 
   private onModalHidden = () => {
@@ -52,11 +30,10 @@ export default class ModalSwipeController extends Controller<HTMLElement> {
       return
     }
 
-    if (window.hasUnsavedChanges || this.shouldShowConfirmOnClose) {
-      this.shouldShowConfirmOnClose = false
+    if (window.hasUnsavedChanges) {
       const confirmModalEl = document.getElementById("confirmModal")
       if (confirmModalEl) {
-        const confirm = new (window as any).bootstrap.Modal(confirmModalEl)
+        const confirm = new window.bootstrap.Modal(confirmModalEl)
         confirm.show()
       }
     }


### PR DESCRIPTION
### Motivation
- Remove fragile touch swipe-to-close behavior and streamline modal close confirmation flow. 
- Ensure `skipNextConfirmation` is consistently reset when a modal is shown. 
- Use a properly typed reference to Bootstrap's `Modal` constructor rather than a loose `any` cast. 

### Description
- Removed touch handling logic and related state (`startY`, `threshold`, and `shouldShowConfirmOnClose`) and the `touchstart`/`touchend` listeners. 
- Added an `onModalShown` handler to reset `skipNextConfirmation` and wired it to the `shown.bs.modal` event on connect/disconnect. 
- Simplified `onModalHidden` to only show the confirm modal when `window.hasUnsavedChanges` is true and to respect `skipNextConfirmation`. 
- Replaced the casted `new (window as any).bootstrap.Modal(...)` with `new window.bootstrap.Modal(...)` for clearer typing. 

### Testing
- Ran TypeScript build (`yarn build`) and the code compiles successfully. 
- Ran the frontend test suite (`yarn test`) and all tests passed. 
- Ran linting (`yarn lint`) with no new warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a243aac4c98832e94398df7d2784b33)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * モーダルダイアログの表示・非表示時における確認動作の処理を改善しました。

* **Chores**
  * 依存ライブラリのバージョン指定を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->