### PR TITLE
CSVエクスポートボタンのアイコンが表示されない問題を修正

### DIFF
--- a/app/views/users/_export_settings.html.erb
+++ b/app/views/users/_export_settings.html.erb
@@ -1,6 +1,5 @@
 <div class="d-flex justify-content-center mb-5">
   <%= link_to export_books_path, class: "btn btn-outline-primary shadow-sm d-inline-flex align-items-center gap-2 px-4 py-1 rounded-pill" do %>
-    <%= bi_icon("file-earmark-arrow-down", css: "is-5") %>
     <span>読書データをCSVでエクスポート</span>
   <% end %>
 </div>


### PR DESCRIPTION
## 概要
マイページ設定画面の「読書データをCSVでエクスポート」ボタンに `(missing icon)` という文字が表示されていた。

## 原因
`app/views/users/_export_settings.html.erb` が呼んでいる `bi_icon("file-earmark-arrow-down", css: "is-5")` の参照先 `app/assets/icons/file-earmark-arrow-down.svg` が存在せず、`IconHelper#bi_icon` のフォールバック文字列 `"(missing icon)"` が表示されていた。

## 対応
アイコンは不要とのことなので、SVGを追加せずボタンからアイコン表示を削除。

Closes #476

## Test plan
- [x] `docker compose run --rm web-test` → 277 examples, 0 failures, 2 pending (既知のWebAuthn系pending)
- [x] `bundle exec rubocop` → 242 files inspected, no offenses detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)