### PR TITLE
CSVエクスポートでTurbo進捗バーが不要に表示される問題を修正

### DIFF
--- a/app/views/users/_export_settings.html.erb
+++ b/app/views/users/_export_settings.html.erb
@@ -1,5 +1,5 @@
 <div class="d-flex justify-content-center mb-5">
-  <%= link_to export_books_path, class: "btn btn-outline-primary shadow-sm d-inline-flex align-items-center gap-2 px-4 py-1 rounded-pill" do %>
+  <%= link_to export_books_path, class: "btn btn-outline-primary shadow-sm d-inline-flex align-items-center gap-2 px-4 py-1 rounded-pill", data: { turbo: false } do %>
     <span>読書データをCSVでエクスポート</span>
   <% end %>
 </div>


### PR DESCRIPTION
## 概要
CSVエクスポートボタンをクリックすると、ファイル自体は即ダウンロードされているのに画面上部のTurbo Driveの進捗バーがだらだら表示され続けていた。

## 原因
`exports#books` は `send_data` で `text/csv` を返す非HTML応答。`link_to export_books_path` に `data: { turbo: false }` が付いていなかったため、Turbo Driveがこのリンクをvisitとして扱ってしまい、進捗バーのライフサイクルがうまく終了しなかった。

同様の非HTML応答/ダウンロード系リンク(`_b_note_row.html.erb`, `_email_settings.html.erb` など)では既に `data: { turbo: false }` で回避されている。

## 対応
`link_to export_books_path` に `data: { turbo: false }` を追加。

Closes #478

## Test plan
- [x] `docker compose run --rm web-test` → 277 examples, 0 failures, 2 pending (既知のWebAuthn系pending)
- [x] `bundle exec rubocop` → 242 files inspected, no offenses detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * エクスポート設定画面のリンク遷移で Turbo を使わないようにし、通常のページ遷移になるよう改善しました。
  * これにより、エクスポート画面への移動がより安定して動作します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->