### PR TITLE
開発環境のPostgresをworktree間で共有する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,26 @@ bundle install
 npm install
 ```
 
+## 共有Postgresコンテナ
+
+worktreeごとに `db` サービスを起動すると、host側のport 5432を奪い合って複数worktreeを同時に動かせない。そのため、Postgresはマシンに1つだけ常駐させ、全worktreeで共有する(DB名はworktreeごとに分離されるためデータが混ざることはない)。
+
+初回のみ、専用の共有ネットワークとコンテナをマシンに1つ起動しておく:
+
+```sh
+docker network create bokrium-shared
+docker volume create bokrium-shared-db-data
+docker run -d --name bokrium-shared-db \
+  --network bokrium-shared \
+  -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres \
+  -v bokrium-shared-db-data:/var/lib/postgresql/data \
+  postgres:16
+```
+
+各worktreeの `docker-compose.yml` は `networks.default` をこの `bokrium-shared` ネットワーク(external)に参加させており、`web`/`web-test` サービスはコンテナ名 `bokrium-shared-db` で接続する。DB名は `${COMPOSE_PROJECT_NAME}` (worktreeのディレクトリ名)からworktreeごとに自動的に一意な名前が組み立てられるので、手動設定は不要。
+
+host側のport 5432は公開しない(Homebrew版postgresなど、host上の既存プロセスと衝突しないようにするため)。
+
 ## テスト実行(Docker)
 
 ローカルのHomebrew版PostgreSQLは `pg_trgm` 拡張のバージョン不整合で動かないことがあるため、開発・テストは `docker-compose.yml` の `web-test` サービスを使う。

--- a/config/database.yml
+++ b/config/database.yml
@@ -9,12 +9,12 @@ default: &default
 
 development:
   <<: *default
-  database: bokrium_development
+  database: <%= ENV.fetch("DATABASE_NAME") { "bokrium_development" } %>
 
 
 test:
   <<: *default
-  database: bokrium_test
+  database: <%= ENV.fetch("DATABASE_NAME") { "bokrium_test" } %>
 
 
 production:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,5 @@
 
 services:
-  db:
-    image: postgres:16
-    environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: bokrium_development
-    ports:
-      - "5432:5432"
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
-
   web:
     image: bokrium-web
     build:
@@ -24,10 +13,9 @@ services:
     ports:
       - "3000:3000"
       - "3036:3036"
-    depends_on:
-      - db
     environment:
-      DATABASE_HOST: db
+      DATABASE_HOST: bokrium-shared-db
+      DATABASE_NAME: ${COMPOSE_PROJECT_NAME}_development
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       RAILS_ENV: development
@@ -70,10 +58,9 @@ services:
       - .:/rails
       - bundle_cache:/usr/local/bundle
       - node_modules:/rails/node_modules
-    depends_on:
-      - db
     environment:
-      DATABASE_HOST: db
+      DATABASE_HOST: bokrium-shared-db
+      DATABASE_NAME: ${COMPOSE_PROJECT_NAME}_test
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       RAILS_ENV: test
@@ -88,6 +75,10 @@ services:
     tty: true
 
 volumes:
-  postgres_data:
   bundle_cache:
   node_modules:
+
+networks:
+  default:
+    external: true
+    name: bokrium-shared


### PR DESCRIPTION
## 概要
issueごとのworktree運用([[CLAUDE.md]])で、各worktreeの `docker-compose.yml` がそれぞれ `db` サービス(host port 5432を専有)を起動していたため、複数worktreeを同時に動かすと `port is already allocated` で衝突していた。

## 対応
- worktree固有の `db` サービスを廃止し、Postgresは専用の外部ネットワーク(`bokrium-shared`)上で1つだけ常駐させる方式に変更
- `web`/`web-test` はコンテナ名 `bokrium-shared-db` で接続
- `config/database.yml` のdatabase名を `DATABASE_NAME` 環境変数で上書き可能にし、`docker-compose.yml` から `${COMPOSE_PROJECT_NAME}` (worktreeのディレクトリ名)を使って自動的にworktreeごとに一意なDB名にする → データは分離されたまま、ポート衝突だけを解消
- `CLAUDE.md` に共有コンテナのセットアップ手順を追記

## 影響範囲
CIは `.github/workflows/ci.yml` 内で独自のpostgresサービスコンテナを使っており `docker-compose.yml` に依存していないため影響なし。

Closes #480

## Test plan
- [x] 共有Postgresコンテナ(`bokrium-shared-db`, ネットワーク `bokrium-shared`)を実際に起動し、`docker compose run --rm web-test` で接続確認
- [x] `480-share-postgres-across-worktrees_test` という worktree 固有のDB名が実際に作成されることを確認
- [x] `docker compose run --rm web-test` → 277 examples, 0 failures, 2 pending (既知のWebAuthn系pending)
- [x] `bundle exec rubocop` → 242 files inspected, no offenses detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)