### PR TITLE
Claude Code向けの.claude設定とワークフロースキルを追加する

### DIFF
--- a/.claude/hooks/rubocop_changed_file.sh
+++ b/.claude/hooks/rubocop_changed_file.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# PostToolUse hook: Edit/Writeされた *.rb にRuboCopをかけ、違反をClaudeにフィードバックする。
+# stdinにはtool呼び出しのJSONが渡される({"tool_input":{"file_path":...}} など)。
+set -u
+
+file=$(jq -r '.tool_input.file_path // empty')
+[[ "$file" == *.rb && -f "$file" ]] || exit 0
+
+# worktree運用のため、対象ファイルが属するリポジトリのルートで実行する
+root=$(cd "$(dirname "$file")" && git rev-parse --show-toplevel 2>/dev/null) || exit 0
+cd "$root" || exit 0
+[[ -f Gemfile ]] || exit 0
+
+# bundle未セットアップのworktreeでは静かにスキップ
+bundle exec rubocop --version >/dev/null 2>&1 || exit 0
+
+output=$(bundle exec rubocop --force-exclusion --format simple "$file" 2>&1)
+if [[ $? -ne 0 ]]; then
+  echo "$output" >&2
+  exit 2
+fi
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,55 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git status*)",
+      "Bash(git diff*)",
+      "Bash(git log*)",
+      "Bash(git fetch*)",
+      "Bash(git branch*)",
+      "Bash(git ls-tree*)",
+      "Bash(git worktree list*)",
+      "Bash(docker ps*)",
+      "Bash(docker compose logs*)",
+      "Bash(docker compose run --rm web-test*)",
+      "Bash(docker compose run --rm -e SKIP_TEST_PREPARE=1 web-test*)",
+      "Bash(docker compose run --rm web bundle exec rails db:prepare*)",
+      "Bash(docker compose run --rm web bundle exec rails db:migrate*)",
+      "Bash(docker compose run --rm web bundle exec rails runner*)",
+      "Bash(docker compose run --rm web bin/vite build*)",
+      "Bash(docker compose run --rm -e NODE_ENV=production web bin/vite build*)",
+      "Bash(docker compose run --rm web npm install*)",
+      "Bash(bundle install*)",
+      "Bash(bundle exec rubocop*)",
+      "Bash(bundle exec brakeman*)",
+      "Bash(bundle exec rspec*)",
+      "Bash(npm install*)",
+      "Bash(npm run*)",
+      "Bash(npm ls*)",
+      "Bash(npx tsc*)",
+      "Bash(gh issue view*)",
+      "Bash(gh issue list*)",
+      "Bash(gh pr view*)",
+      "Bash(gh pr list*)",
+      "Bash(gh pr checks*)",
+      "Bash(gh pr diff*)",
+      "Bash(gh run view*)",
+      "Bash(gh run list*)",
+      "Bash(curl -sf https://raw.githubusercontent.com/twbs/icons/*)"
+    ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/rubocop_changed_file.sh",
+            "timeout": 60,
+            "statusMessage": "RuboCop"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: ship
+description: 現在のissue worktreeの作業を出荷する。ローカルゲート(RuboCop/Brakeman/RSpec/型チェック)→PR作成→auto-merge→マージ後のissueコメント・worktree片付けまで。「PRを出して」「マージまでやって」のときに使う。
+---
+
+# 出荷フロー
+
+前提: issue worktree上で作業しており、変更はコミット済み(未コミットがあれば先に整理してコミットする)。
+
+## 1. ローカルゲート(全部通るまでPRを作らない)
+
+```sh
+bundle exec rubocop
+bundle exec brakeman -q --no-pager   # CIのlintゲートと同一。permit!等はここで落ちる
+npm run typecheck
+docker compose run --rm web-test     # フルスイート(アセット・DB準備込み)
+```
+
+2回目以降のRSpecは `docker compose run --rm -e SKIP_TEST_PREPARE=1 web-test bundle exec rspec` で短縮できる。
+
+ランタイムに触れる変更なら、PR前に組み込みの /verify(プロジェクトのverifyスキル)で実際に動かして確認する。
+
+## 2. PR作成
+
+```sh
+git push -u origin issue/{N}-{name}
+gh pr create --repo Peeaaaa-art/Bokrium --title "{日本語タイトル}" --body-file {body}
+```
+
+本文はリポジトリの慣例に従う:
+
+- セクション: `## 概要` `## 対応` `## 影響範囲` `## Test plan`(実施済み項目をチェック済みで列挙)
+- issueが完結するなら `Closes #{N}`、フェーズ分割なら `Part of #{N}`
+- 末尾: `🤖 Generated with [Claude Code](https://claude.com/claude-code)`
+
+## 3. マージ(squash)
+
+```sh
+gh pr merge {PR} --repo Peeaaaa-art/Bokrium --squash --auto --delete-branch
+```
+
+Monitorでマージ完了/CI失敗を監視する(`gh pr checks {PR}` で失敗ジョブ名を出す)。CIが落ちたら原因を直してpushし、監視を続ける。
+
+## 4. マージ後の片付け
+
+1. issueに完了コメント(やったこと+残タスク。フェーズ分割ならissueは閉じない)
+2. worktreeの後始末:
+
+```sh
+docker compose down --remove-orphans
+docker volume rm {dir}_bundle_cache {dir}_node_modules
+cd ~/Workspace/Bokrium-worktrees/Bokrium
+git worktree remove --force ~/Workspace/Bokrium-worktrees/{N}-{name}
+git branch -D issue/{N}-{name}
+```
+
+共有Postgres内のworktree用DB(`{dir}_development` / `{dir}_test`)は害がないので基本残してよい。
+
+3. ユーザーにPR URL・マージコミット・片付け結果を報告する。

--- a/.claude/skills/start-issue/SKILL.md
+++ b/.claude/skills/start-issue/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: start-issue
+description: GitHub issueの作業を開始する。issue番号を引数に取り(例 /start-issue 471)、issue確認→worktree作成→依存セットアップ→環境確認まで行う。ユーザーが「issue Nを始めて」「issue Nやろう」と言ったときにも使う。
+---
+
+# issue作業の開始
+
+引数としてissue番号が渡される。以下を順に実行する。
+
+## 1. issueを確認する
+
+```sh
+gh issue view {N} --repo Peeaaaa-art/Bokrium --comments
+```
+
+実装プランが書かれていなければ、着手前にプランを起案してissueにコメントし、ユーザーに方向性を確認する(CLAUDE.mdのIssue駆動開発)。
+
+## 2. worktreeを作成する
+
+ブランチ名は `issue/{N}-{内容を表す英語kebab-case}`、worktreeは `~/Workspace/Bokrium-worktrees/{N}-{内容}/`。
+
+```sh
+git fetch origin main
+git worktree add ~/Workspace/Bokrium-worktrees/{N}-{name} -b issue/{N}-{name} origin/main
+```
+
+## 3. セットアップ
+
+```sh
+cd ~/Workspace/Bokrium-worktrees/{N}-{name}
+cp ~/Workspace/Bokrium-worktrees/Bokrium/.env .env   # メインcheckoutからコピー
+bundle install
+npm install
+```
+
+共有Postgresコンテナの稼働確認(なければCLAUDE.mdの初回セットアップ手順で起動):
+
+```sh
+docker ps --filter name=bokrium-shared-db --format '{{.Names}} {{.Status}}'
+```
+
+## 4. 注意事項
+
+- **npmパッケージを追加したら**、コンテナ内のnode_modulesボリュームは古いままなので、テスト前に `docker compose run --rm -e SKIP_TEST_PREPARE=1 web-test npm install` を実行する
+- テストは `docker compose run --rm web-test`(ホストのPostgresは使わない)
+- devサーバーやDB操作もdocker compose経由(AGENTS.md参照)
+
+## 5. 報告
+
+worktreeパス・ブランチ名・環境確認の結果をユーザーに報告し、実装に入る。

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: verify
+description: 変更をBokriumの実アプリで動かしてエンドツーエンドで確認する手順。devサーバー起動、テストユーザー、ログイン、主要画面の導線、iPad実機確認、本番相当アセットでの確認。
+---
+
+# Bokriumの動作確認
+
+## 起動
+
+```sh
+docker compose run --rm web bundle exec rails db:prepare   # そのworktreeで初回のみ
+docker compose up web    # バックグラウンドで起動(Rails:3000 + Vite:3036)
+```
+
+`curl -s http://localhost:3000/up` が200を返すまで待つ(初回は1分程度)。
+
+## テストデータ
+
+devデータベースはworktreeごとに独立している。検証用ユーザーと本を冪等に作る:
+
+```sh
+docker compose run --rm web bundle exec rails runner "
+u = User.find_or_create_by!(email: 'dev@example.com') { |x| x.password = 'password123'; x.password_confirmation = 'password123'; x.confirmed_at = Time.current }
+b = Book.find_or_create_by!(user: u, title: '検証用の本') { |x| x.status = :want_to_read }
+puts \"user=#{u.id} book=#{b.id}\""
+```
+
+## ブラウザでの確認
+
+- ログイン: `/users/sign_in` に `dev@example.com` / `password123`
+  - 1Password拡張のアイコンが入力欄の右端に被ってクリックを吸うことがある。**フィールドの左寄りをクリック**する。空フォームで送信されてしまったら座標クリックで再入力
+- 主要画面: `/books`(本棚)、`/books/:id`(本詳細。ツールバーにタグ/画像/手書きノート/設定)、`/books/:id/handwritten_note`(Excalidraw手書きノート)
+- サーバーログ: `docker compose logs web --since 5m`。**ブラウザ拡張のネットワーク表示は204レスポンスを503と誤表示することがある — サーバーログを正とする**
+- Turbo遷移とフルリロードの両方で確認する(マウント/復元のバグはTurbo遷移でだけ出ることがある)
+
+## 本番相当アセットでの確認(体感性能を見るとき)
+
+開発ビルドはReact/依存ライブラリが遅い開発版になるため、描画性能などの体感はあてにならない。本番相当で確認するには:
+
+```sh
+docker compose stop
+docker compose run --rm -e NODE_ENV=production web bin/vite build   # public/vite-devへ出力
+docker compose run --rm --service-ports web bundle exec rails server -b 0.0.0.0 -p 3000
+```
+
+Vite devサーバーが不在だとvite_rubyがビルド済みマニフェスト配信にフォールバックする。
+
+## iPad等の実機確認
+
+- MacのLAN IP(`ipconfig getifaddr en0`)を使い、同一Wi-Fiから `http://{IP}:3000`
+- RailsはIPアドレスでのアクセスをデフォルト許可(ホスト名と違い設定不要)
+- Apple Pencilの書き味を見るときはiPadの**低電力モードをオフ**にする(サンプリングレートが落ちる)
+
+## 片付け
+
+```sh
+docker compose down
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Bokrium(bokrium.com)の開発方針。
 
 ## Worktree
 
-issueごとに作業用のworktreeを作る。メインの作業ディレクトリ(`~/Workspace/Bokrium`)の状態を汚さないため。
+issueごとに作業用のworktreeを作る。メインのcheckout(`~/Workspace/Bokrium-worktrees/Bokrium`)の状態を汚さないため。
 
 - 配置場所: `~/Workspace/Bokrium-worktrees/{issue番号}-{実装内容を表す英語}/`
 - ディレクトリ名はブランチ名から `issue/` を除いたもの
@@ -31,9 +31,15 @@ git worktree add ~/Workspace/Bokrium-worktrees/{issue番号}-{実装内容を表
 新しいworktreeでは、gitに含まれない以下のセットアップが別途必要:
 
 ```sh
-cp ~/Workspace/Bokrium/.env .env
+cp ~/Workspace/Bokrium-worktrees/Bokrium/.env .env
 bundle install
 npm install
+```
+
+**npmパッケージを追加・更新したら**、Dockerボリューム内のnode_modulesは古いままなので、テスト前にコンテナ内でもインストールする:
+
+```sh
+docker compose run --rm -e SKIP_TEST_PREPARE=1 web-test npm install
 ```
 
 ## 共有Postgresコンテナ
@@ -69,3 +75,28 @@ docker compose run --rm web-test
 ```sh
 docker compose run --rm web-test bundle exec rspec spec/requests/exports_spec.rb
 ```
+
+## PR前のローカルゲート
+
+CIで落ちる前にローカルで全部通す(Brakemanはlintゲートとして必須。`permit!`などはここで落ちる):
+
+```sh
+bundle exec rubocop
+bundle exec brakeman -q --no-pager
+npm run typecheck
+docker compose run --rm web-test
+```
+
+PRの本文は `## 概要` `## 対応` `## 影響範囲` `## Test plan` 形式、マージはsquash。
+
+## フロントエンドの規約
+
+- アイコンは `bi_icon` ヘルパー経由で `app/assets/icons/{name}.svg` を読む。未追加のアイコンは公式Bootstrap Iconsから取得する:
+  `curl -sf https://raw.githubusercontent.com/twbs/icons/main/icons/{name}.svg -o app/assets/icons/{name}.svg`
+- ページ専用のVite entrypoint(`app/frontend/entrypoints/*.tsx`)を追加するときは、`turbo:load` リスナーに加えて**モジュール評価時の即時マウント**も行う。Turbo遷移で初めて読み込まれた場合、`turbo:load` は発火済みのため(実例: `handwritten_note.tsx`)
+- 重いライブラリはページ専用entrypointに分離し、既存ページのバンドルに影響させない(`vite build` 後にマニフェストで確認)
+
+## Claude Code
+
+- セッションは**worktreeディレクトリ内で起動する**。`.claude/settings.json`(権限allowlist・RuboCopフック)とプロジェクトスキルはそこから読み込まれる
+- スキル: `/start-issue {N}`(issue着手の定型セットアップ)、`/ship`(ローカルゲート→PR→auto-merge→片付け)、`/verify`(実アプリでの動作確認手順)

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "@types/react-dom": "^19.1.6",
         "playwright": "1.58.2",
         "sass": "^1.89.2",
+        "typescript": "^6.0.3",
         "vite": "^7.3.0",
         "vite-plugin-ruby": "^5.1.1"
       },
@@ -5200,6 +5201,20 @@
       "license": "MIT",
       "dependencies": {
         "zustand": "^4.3.2"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/uc.micro": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@excalidraw/excalidraw": "^0.18.1",
@@ -36,6 +37,7 @@
     "@types/react-dom": "^19.1.6",
     "playwright": "1.58.2",
     "sass": "^1.89.2",
+    "typescript": "^6.0.3",
     "vite": "^7.3.0",
     "vite-plugin-ruby": "^5.1.1"
   }

--- a/types/assets.d.ts
+++ b/types/assets.d.ts
@@ -1,0 +1,3 @@
+// Viteが処理するアセットのside-effect import用の型宣言
+declare module "*.css";
+declare module "*.scss";


### PR DESCRIPTION
## 概要
#471の実装サイクルで得た知見をリポジトリに定着させ、Claude Codeでの開発のQCDを上げる。定型コマンドの承認待ち・CIで初めて発覚するBrakeman警告・毎回組み立て直す検証手順、をなくす。

## 対応
- **`.claude/settings.json`**: 定型的な開発コマンド(docker compose run web-test / rubocop / brakeman / gh閲覧系など)の権限allowlist(34ルール)+ `*.rb`編集時にRuboCopを自動実行するPostToolUseフック
- **`.claude/hooks/rubocop_changed_file.sh`**: フック本体。worktree運用を考慮し対象ファイルのリポジトリルートで実行、bundle未セットアップ環境では静かにスキップ。クリーン/違反/非Rubyの3ケースをパイプテスト済み
- **`.claude/skills/start-issue/`**: issue着手の定型フロー(issue確認→worktree→.env→依存→共有Postgres確認)
- **`.claude/skills/ship/`**: 出荷フロー(ローカルゲート→PR→auto-merge squash→マージ後のissueコメント・worktree片付け)
- **`.claude/skills/verify/`**: 実アプリでの動作確認手順(起動、devユーザーのシード、ログインの罠、本番相当アセットでの性能確認、iPad実機確認)
- **CLAUDE.md**: `.env`コピー元の古いパスを実際の場所(`~/Workspace/Bokrium-worktrees/Bokrium`)に修正、コンテナ内npm installの罠、PR前ローカルゲート、フロントエンド規約(bi_iconのSVG追加、Vite entrypointのTurbo対応)、Claude Codeセッションの起動場所
- **`typescript` devDependency + `npm run typecheck`**: 型チェックをローカルゲートに追加可能に。CSSのside-effect import用に `types/assets.d.ts` を追加

## 影響範囲
- アプリケーションコードの変更なし(Ruby/フロントの挙動は不変)
- `.claude/settings.json` はセッションをリポジトリ/worktree内で起動したときに読み込まれる
- TypeScript追加はdevDependenciesのみ。Viteのビルドには影響しない

Closes #483

## Test plan
- [x] `bundle exec rubocop` → 248 files, no offenses
- [x] `bundle exec brakeman -q` → 0 warnings
- [x] `npm run typecheck` → エラーなし(TypeScript 6.0.3)
- [x] `docker compose run --rm web-test` → 292 examples, 0 failures, 2 pending(既知)
- [x] フックのパイプテスト: 違反ファイル→exit 2+stderr出力、クリーン/非Ruby/除外パス→exit 0
- [x] `jq -e` によるsettings.jsonの構文・スキーマ検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)
