### PR TITLE
手書きノートの複数ページ・サムネイル一覧・iPhone閲覧に対応する

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -46,6 +46,7 @@ class BooksController < ApplicationController
     @memos = @book.memos.order(created_at: :desc)
     @new_memo = @book.memos.new(user_id: current_user.id)
     @user_tag = UserTag.new
+    @handwritten_notes = @book.handwritten_notes.ordered.with_attached_thumbnail_s3
   end
 
   def new

--- a/app/controllers/handwritten_notes_controller.rb
+++ b/app/controllers/handwritten_notes_controller.rb
@@ -1,12 +1,38 @@
 class HandwrittenNotesController < ApplicationController
   before_action :authenticate_user!
   before_action :set_book
-  before_action :set_handwritten_note
+  before_action :set_handwritten_note, only: [ :show, :update, :destroy, :thumbnail ]
+
+  def create
+    next_position = (@book.handwritten_notes.maximum(:position) || -1) + 1
+    note = @book.handwritten_notes.create!(user: current_user, data: {}, position: next_position)
+    redirect_to book_handwritten_note_path(@book, note)
+  end
 
   def show; end
 
   def update
-    if @handwritten_note.update(data: handwritten_note_data)
+    if @handwritten_note.update(handwritten_note_attributes)
+      head :no_content
+    else
+      render json: { errors: @handwritten_note.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @handwritten_note.destroy
+    flash[:info] = "手書きノートを削除しました。"
+    redirect_to book_path(@book), status: :see_other
+  end
+
+  def thumbnail
+    file = params[:thumbnail]
+    unless file.is_a?(ActionDispatch::Http::UploadedFile)
+      raise ActionController::BadRequest, "thumbnail file is required"
+    end
+
+    @handwritten_note.thumbnail_s3.attach(file)
+    if @handwritten_note.valid?
       head :no_content
     else
       render json: { errors: @handwritten_note.errors.full_messages }, status: :unprocessable_entity
@@ -19,21 +45,33 @@ class HandwrittenNotesController < ApplicationController
     @book = current_user.books.find(params[:book_id])
   end
 
-  # Phase 1では1冊につき1ノート。初回アクセス時に空ノートを作る
   def set_handwritten_note
-    @handwritten_note = @book.handwritten_notes.order(:position, :id).first ||
-                        @book.handwritten_notes.create!(user: current_user, data: {})
+    @handwritten_note = @book.handwritten_notes.find(params[:id])
   end
 
   # Excalidrawのシーンは任意のキーを持つJSONのため、Strong Parametersは通さず
   # ボディを直接パースする。dataはjsonbカラムにのみ代入され、
   # サイズ上限はモデル側で検証する
-  def handwritten_note_data
+  def handwritten_note_attributes
     body = JSON.parse(request.raw_post)
-    data = body.is_a?(Hash) ? body.dig("handwritten_note", "data") : nil
-    raise ActionController::BadRequest, "data must be an object" unless data.is_a?(Hash)
+    payload = body.is_a?(Hash) ? body["handwritten_note"] : nil
+    raise ActionController::BadRequest, "handwritten_note must be an object" unless payload.is_a?(Hash)
 
-    data
+    attributes = {}
+    if payload.key?("data")
+      raise ActionController::BadRequest, "data must be an object" unless payload["data"].is_a?(Hash)
+
+      attributes[:data] = payload["data"]
+    end
+    if payload.key?("title")
+      title = payload["title"]
+      raise ActionController::BadRequest, "title must be a string" unless title.nil? || title.is_a?(String)
+
+      attributes[:title] = title&.strip.presence
+    end
+    raise ActionController::BadRequest, "nothing to update" if attributes.empty?
+
+    attributes
   rescue JSON::ParserError
     raise ActionController::BadRequest, "request body must be JSON"
   end

--- a/app/frontend/entrypoints/components/HandwrittenNoteEditor.tsx
+++ b/app/frontend/entrypoints/components/HandwrittenNoteEditor.tsx
@@ -1,5 +1,10 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { Excalidraw, restore, getSceneVersion } from "@excalidraw/excalidraw"
+import {
+  Excalidraw,
+  restore,
+  getSceneVersion,
+  exportToBlob,
+} from "@excalidraw/excalidraw"
 import "@excalidraw/excalidraw/index.css"
 
 type ExcalidrawImperativeAPI = Parameters<
@@ -15,6 +20,9 @@ const PERSISTED_APP_STATE_KEYS = [
 ] as const
 
 const AUTOSAVE_DEBOUNCE_MS = 1200
+const TITLE_DEBOUNCE_MS = 800
+const THUMBNAIL_DEBOUNCE_MS = 5000
+const THUMBNAIL_MAX_SIZE = 480
 
 type SaveStatus = "idle" | "saving" | "saved" | "error"
 
@@ -25,6 +33,8 @@ interface SceneData {
 
 interface Props {
   updateUrl: string
+  thumbnailUrl: string
+  viewMode: boolean
   initialSceneData: SceneData
 }
 
@@ -37,10 +47,13 @@ function csrfToken(): string {
 
 export default function HandwrittenNoteEditor({
   updateUrl,
+  thumbnailUrl,
+  viewMode,
   initialSceneData,
 }: Props): React.JSX.Element {
   const apiRef = useRef<ExcalidrawImperativeAPI | null>(null)
   const saveTimerRef = useRef<number | null>(null)
+  const thumbnailTimerRef = useRef<number | null>(null)
   const lastSavedMarkerRef = useRef<string | null>(null)
   const [status, setStatus] = useState<SaveStatus>("idle")
 
@@ -92,6 +105,50 @@ export default function HandwrittenNoteEditor({
     return `${getSceneVersion(api.getSceneElementsIncludingDeleted())}|${appStatePart}`
   }, [])
 
+  // サムネイルは補助情報。失敗しても本体の保存フローには影響させない
+  const uploadThumbnail = useCallback(
+    async (options: { keepalive?: boolean } = {}) => {
+      const api = apiRef.current
+      if (!api) return
+      const elements = api.getSceneElements()
+      if (elements.length === 0) return
+
+      try {
+        const blob = await exportToBlob({
+          elements,
+          appState: api.getAppState(),
+          files: api.getFiles(),
+          maxWidthOrHeight: THUMBNAIL_MAX_SIZE,
+          mimeType: "image/png",
+        })
+        const form = new FormData()
+        form.append("thumbnail", blob, "thumbnail.png")
+        await fetch(thumbnailUrl, {
+          method: "PATCH",
+          headers: {
+            "X-CSRF-Token": csrfToken(),
+            Accept: "application/json",
+          },
+          body: form,
+          keepalive: options.keepalive ?? false,
+        })
+      } catch {
+        // no-op
+      }
+    },
+    [thumbnailUrl]
+  )
+
+  const scheduleThumbnail = useCallback(() => {
+    if (thumbnailTimerRef.current !== null) {
+      window.clearTimeout(thumbnailTimerRef.current)
+    }
+    thumbnailTimerRef.current = window.setTimeout(() => {
+      thumbnailTimerRef.current = null
+      void uploadThumbnail()
+    }, THUMBNAIL_DEBOUNCE_MS)
+  }, [uploadThumbnail])
+
   const doSave = useCallback(
     async (options: { keepalive?: boolean } = {}) => {
       const marker = sceneMarker()
@@ -114,11 +171,12 @@ export default function HandwrittenNoteEditor({
         if (!response.ok) throw new Error(`save failed: ${response.status}`)
         lastSavedMarkerRef.current = marker
         setStatus("saved")
+        scheduleThumbnail()
       } catch {
         setStatus("error")
       }
     },
-    [buildPersistedScene, updateUrl]
+    [sceneMarker, buildPersistedScene, updateUrl, scheduleThumbnail]
   )
 
   const flushSave = useCallback(
@@ -127,14 +185,20 @@ export default function HandwrittenNoteEditor({
         window.clearTimeout(saveTimerRef.current)
         saveTimerRef.current = null
       }
+      if (thumbnailTimerRef.current !== null) {
+        window.clearTimeout(thumbnailTimerRef.current)
+        thumbnailTimerRef.current = null
+        void uploadThumbnail(options)
+      }
       void doSave(options)
     },
-    [doSave]
+    [doSave, uploadThumbnail]
   )
 
   // 描画中のonChangeは毎フレーム発火するため、ここでは重い処理をしない。
   // シーンバージョンの計算・比較は保存時（debounce後）にまとめて行う
   const handleChange = useCallback(() => {
+    if (viewMode) return
     if (lastSavedMarkerRef.current === null) {
       // 初回onChange（マウント直後の復元描画）は保存対象にしない
       lastSavedMarkerRef.current = sceneMarker()
@@ -148,9 +212,69 @@ export default function HandwrittenNoteEditor({
       saveTimerRef.current = null
       void doSave()
     }, AUTOSAVE_DEBOUNCE_MS)
-  }, [sceneMarker, doSave])
+  }, [viewMode, sceneMarker, doSave])
+
+  // タイトル入力はReactの外（ヘッダー行）にあるため、直接リッスンする
+  useEffect(() => {
+    if (viewMode) return
+
+    const input = document.querySelector<HTMLInputElement>(
+      "#handwritten-note-title"
+    )
+    if (!input) return
+
+    let timer: number | null = null
+    let lastSavedTitle = input.value
+
+    const saveTitle = async (): Promise<void> => {
+      if (input.value === lastSavedTitle) return
+      const title = input.value
+      setStatus("saving")
+      try {
+        const response = await fetch(updateUrl, {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            "X-CSRF-Token": csrfToken(),
+            Accept: "application/json",
+          },
+          body: JSON.stringify({ handwritten_note: { title } }),
+        })
+        if (!response.ok) throw new Error(`save failed: ${response.status}`)
+        lastSavedTitle = title
+        setStatus("saved")
+      } catch {
+        setStatus("error")
+      }
+    }
+
+    const onInput = (): void => {
+      if (timer !== null) window.clearTimeout(timer)
+      timer = window.setTimeout(() => {
+        timer = null
+        void saveTitle()
+      }, TITLE_DEBOUNCE_MS)
+    }
+    const onBlur = (): void => {
+      if (timer !== null) {
+        window.clearTimeout(timer)
+        timer = null
+      }
+      void saveTitle()
+    }
+
+    input.addEventListener("input", onInput)
+    input.addEventListener("blur", onBlur)
+    return () => {
+      input.removeEventListener("input", onInput)
+      input.removeEventListener("blur", onBlur)
+      if (timer !== null) window.clearTimeout(timer)
+    }
+  }, [viewMode, updateUrl])
 
   useEffect(() => {
+    if (viewMode) return
+
     // iPad Safariはタブをすぐ破棄するので、画面を離れる瞬間に必ず書き出す
     const onPageHide = (): void => flushSave({ keepalive: true })
     const onVisibilityChange = (): void => {
@@ -168,8 +292,11 @@ export default function HandwrittenNoteEditor({
       if (saveTimerRef.current !== null) {
         window.clearTimeout(saveTimerRef.current)
       }
+      if (thumbnailTimerRef.current !== null) {
+        window.clearTimeout(thumbnailTimerRef.current)
+      }
     }
-  }, [flushSave])
+  }, [viewMode, flushSave])
 
   const statusLabel: Record<SaveStatus, string> = {
     idle: "",
@@ -186,26 +313,31 @@ export default function HandwrittenNoteEditor({
       initialData={initialData}
       onChange={handleChange}
       langCode="ja-JP"
-      renderTopRightUI={() => (
-        <div
-          className={`d-flex align-items-center small px-2 ${
-            status === "error" ? "text-danger" : "text-secondary"
-          }`}
-          style={{ whiteSpace: "nowrap" }}
-        >
-          {status === "error" ? (
-            <button
-              type="button"
-              className="btn btn-sm btn-outline-danger py-0"
-              onClick={() => flushSave()}
-            >
-              {statusLabel[status]}（再試行）
-            </button>
-          ) : (
-            statusLabel[status]
-          )}
-        </div>
-      )}
+      viewModeEnabled={viewMode}
+      renderTopRightUI={
+        viewMode
+          ? undefined
+          : () => (
+              <div
+                className={`d-flex align-items-center small px-2 ${
+                  status === "error" ? "text-danger" : "text-secondary"
+                }`}
+                style={{ whiteSpace: "nowrap" }}
+              >
+                {status === "error" ? (
+                  <button
+                    type="button"
+                    className="btn btn-sm btn-outline-danger py-0"
+                    onClick={() => flushSave()}
+                  >
+                    {statusLabel[status]}（再試行）
+                  </button>
+                ) : (
+                  statusLabel[status]
+                )}
+              </div>
+            )
+      }
     />
   )
 }

--- a/app/frontend/entrypoints/handwritten_note.tsx
+++ b/app/frontend/entrypoints/handwritten_note.tsx
@@ -20,7 +20,9 @@ function mountHandwrittenNote(): void {
   if (!element) return
 
   const updateUrl = element.dataset.updateUrl
-  if (!updateUrl) return
+  const thumbnailUrl = element.dataset.thumbnailUrl
+  if (!updateUrl || !thumbnailUrl) return
+  const viewMode = element.dataset.viewMode === "true"
 
   let initialSceneData = {}
   const dataScript = document.querySelector("#handwritten-note-data")
@@ -37,6 +39,8 @@ function mountHandwrittenNote(): void {
   mountedRoot.render(
     <HandwrittenNoteEditor
       updateUrl={updateUrl}
+      thumbnailUrl={thumbnailUrl}
+      viewMode={viewMode}
       initialSceneData={initialSceneData}
     />
   )

--- a/app/models/handwritten_note.rb
+++ b/app/models/handwritten_note.rb
@@ -1,12 +1,25 @@
 class HandwrittenNote < ApplicationRecord
+  include UploadValidations
+
   # Excalidrawのシーン全体をdataに保存するため、肥大化だけ防ぐ
   MAX_DATA_BYTESIZE = 2.megabytes
 
   belongs_to :user
   belongs_to :book
 
+  has_one_attached :thumbnail_s3,
+    service: (Rails.env.test? ? :test : :cloudflare_private_r2),
+    dependent: :purge
+
+  scope :ordered, -> { order(:position, :id) }
+
   validates :title, length: { maximum: 100, message: ": タイトルは100文字以内で入力してください" }, allow_blank: true
   validate :validate_data_structure
+  validate :validate_thumbnail_format
+
+  def display_title
+    title.presence || "手書きノート"
+  end
 
   private
 
@@ -19,5 +32,9 @@ class HandwrittenNote < ApplicationRecord
     if data.to_json.bytesize > MAX_DATA_BYTESIZE
       errors.add(:data, ": 手書きデータが大きすぎます（2MBまで）")
     end
+  end
+
+  def validate_thumbnail_format
+    validate_upload_format(thumbnail_s3, :thumbnail_s3)
   end
 end

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -61,8 +61,14 @@
           <% end %>
         </div>
         <!-- 手書きノート -->
-        <%= link_to book_handwritten_note_path(@book), class: "btn btn-sm btn-icon text-white", title: "手書きノート" do %>
-          <%= bi_icon("vector-pen", css: "is-5 icon-refined") %>
+        <% if @handwritten_notes.present? %>
+          <%= link_to book_handwritten_note_path(@book, @handwritten_notes.first), class: "btn btn-sm btn-icon text-white", title: "手書きノート" do %>
+            <%= bi_icon("vector-pen", css: "is-5 icon-refined") %>
+          <% end %>
+        <% else %>
+          <%= button_to book_handwritten_notes_path(@book), method: :post, class: "btn btn-sm btn-icon text-white", form_class: "d-inline", title: "手書きノートを作成" do %>
+            <%= bi_icon("vector-pen", css: "is-5 icon-refined") %>
+          <% end %>
         <% end %>
         <!-- アクション：ギアボタン -->
         <button class="btn btn-sm btn-icon text-white" type="button" data-bs-toggle="modal" data-bs-target="#settingsModal" style="cursor: pointer;">
@@ -86,6 +92,25 @@
       <div class="px-1 pt-1">
         <%= render "tags/tag_badge_list", book: @book %>
       </div>
+      <!-- 手書きノートリスト -->
+      <% if @handwritten_notes.present? %>
+        <div class="row row-cols-4 row-cols-md-6 g-2 mb-2" id="handwritten-note-list">
+          <% @handwritten_notes.each do |note| %>
+            <div class="col" id="handwritten_note_<%= note.id %>">
+              <%= render "handwritten_notes/card", book: @book, note: note %>
+            </div>
+          <% end %>
+          <div class="col d-flex align-items-center justify-content-center">
+            <%= button_to book_handwritten_notes_path(@book), method: :post,
+                  class: "btn btn-outline-secondary d-flex flex-column align-items-center justify-content-center",
+                  style: "width: 100%; aspect-ratio: 3 / 4; border-style: dashed;",
+                  title: "手書きノートを追加" do %>
+              <%= bi_icon("vector-pen", css: "is-5") %>
+              <span class="small mt-1">追加</span>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
       <!-- 画像リスト -->
       <div class="row row-cols-4 row-cols-md-6 g-2 mb-4" id="image-list">
         <% @book.images.each_with_index do |image, identifier| %>

--- a/app/views/handwritten_notes/_card.html.erb
+++ b/app/views/handwritten_notes/_card.html.erb
@@ -1,0 +1,24 @@
+<%= button_to book_handwritten_note_path(book, note),
+              method: :delete,
+              data: { turbo_confirm: "「#{note.display_title}」を削除しますか？" },
+              class: "btn btn-sm d-flex align-items-center justify-content-center mx-auto mt-2",
+              title: "手書きノートを削除" do %>
+  <%= bi_icon("trash2", css: "is-7") %>
+<% end %>
+
+<%= link_to book_handwritten_note_path(book, note), class: "text-decoration-none" do %>
+  <div class="card">
+    <% if note.thumbnail_s3.attached? %>
+      <%= lazy_image_tag note.thumbnail_s3,
+            class: "card-img-top img-fluid",
+            alt: note.display_title,
+            style: "max-width: 240px; width: 100%; aspect-ratio: 3 / 4; object-fit: contain; background: #fff;" %>
+    <% else %>
+      <div class="card-img-top d-flex align-items-center justify-content-center text-secondary bg-white"
+           style="max-width: 240px; width: 100%; aspect-ratio: 3 / 4;">
+        <%= bi_icon("vector-pen", css: "is-5") %>
+      </div>
+    <% end %>
+  </div>
+  <div class="small text-secondary text-truncate text-center mt-1"><%= note.display_title %></div>
+<% end %>

--- a/app/views/handwritten_notes/show.html.erb
+++ b/app/views/handwritten_notes/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "手書きノート - #{@book.title} - Bokrium" %>
+<% content_for :title, "#{@handwritten_note.display_title} - #{@book.title} - Bokrium" %>
 <% content_for :head do %>
   <meta name="turbo-cache-control" content="no-cache">
   <%= vite_javascript_tag "handwritten_note.tsx" %>
@@ -9,12 +9,21 @@
     <%= link_to book_path(@book), class: "btn btn-sm btn-outline-secondary rounded-pill px-3 flex-shrink-0" do %>
       <%= bi_icon("arrow-left", css: "is-6") %> 本の詳細へ
     <% end %>
-    <div class="fw-bold text-truncate"><%= @book.title %></div>
+    <div class="text-secondary text-truncate flex-shrink-0" style="max-width: 30%;"><%= @book.title %></div>
+    <input type="text"
+           id="handwritten-note-title"
+           class="form-control form-control-sm border-0 fw-bold"
+           placeholder="ノートのタイトル"
+           maxlength="100"
+           value="<%= @handwritten_note.title %>"
+           <%= "readonly" if mobile? %>>
   </div>
 
   <div id="handwritten-note-root"
        class="handwritten-note-canvas border rounded shadow-sm"
-       data-update-url="<%= book_handwritten_note_path(@book) %>"></div>
+       data-update-url="<%= book_handwritten_note_path(@book, @handwritten_note) %>"
+       data-thumbnail-url="<%= thumbnail_book_handwritten_note_path(@book, @handwritten_note) %>"
+       data-view-mode="<%= mobile? %>"></div>
 
   <script type="application/json" id="handwritten-note-data">
     <%= raw({ data: @handwritten_note.data }.to_json) %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -8,6 +8,8 @@ Rails.application.configure do
     Bullet.enable        = true
     Bullet.bullet_logger = true
     Bullet.raise         = true # raise an error if n+1 query occurs
+    # ActiveStorageがattach時に内部で行うincludes(:record)をBulletが誤検知するため除外する
+    Bullet.add_safelist type: :unused_eager_loading, class_name: "ActiveStorage::Attachment", association: :record
   end
 
   # Settings specified here will take precedence over those in config/application.rb.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,7 +66,9 @@ Rails.application.routes.draw do
   resources :books do
     resources :memos, only: [ :create, :new, :edit, :update, :destroy ]
     resources :images, only: [ :create, :destroy ]
-    resource :handwritten_note, only: [ :show, :update ]
+    resources :handwritten_notes, only: [ :create, :show, :update, :destroy ] do
+      patch :thumbnail, on: :member
+    end
     resource :row, only: [ :show, :edit, :update ], controller: "books/rows"
     resource :tags, only: [], controller: "books/tags" do
       post :toggle

--- a/spec/models/handwritten_note_spec.rb
+++ b/spec/models/handwritten_note_spec.rb
@@ -46,4 +46,21 @@ RSpec.describe HandwrittenNote, type: :model do
       expect { note.book.destroy }.to change(HandwrittenNote, :count).by(-1)
     end
   end
+
+  describe ".ordered" do
+    it "position昇順、同positionはid昇順で並ぶ" do
+      user = create(:user)
+      book = create(:book, user: user)
+      second = create(:handwritten_note, user: user, book: book, position: 1)
+      first = create(:handwritten_note, user: user, book: book, position: 0)
+      expect(book.handwritten_notes.ordered).to eq([ first, second ])
+    end
+  end
+
+  describe "#display_title" do
+    it "タイトルがあればそれを、なければ既定名を返す" do
+      expect(build(:handwritten_note, title: "読書マップ").display_title).to eq("読書マップ")
+      expect(build(:handwritten_note, title: nil).display_title).to eq("手書きノート")
+    end
+  end
 end

--- a/spec/requests/handwritten_notes_spec.rb
+++ b/spec/requests/handwritten_notes_spec.rb
@@ -3,8 +3,10 @@ require 'rails_helper'
 RSpec.describe "HandwrittenNotes", type: :request do
   let(:user) { FactoryBot.create(:user) }
   let(:book) { FactoryBot.create(:book, user: user) }
+  let(:note) { FactoryBot.create(:handwritten_note, user: user, book: book) }
   let(:other_user) { FactoryBot.create(:user) }
   let(:other_book) { FactoryBot.create(:book, user: other_user) }
+  let(:other_note) { FactoryBot.create(:handwritten_note, user: other_user, book: other_book) }
 
   let(:scene_params) do
     {
@@ -21,7 +23,7 @@ RSpec.describe "HandwrittenNotes", type: :request do
 
   describe "未ログイン" do
     it "ログイン画面へリダイレクトされる" do
-      get book_handwritten_note_path(book)
+      get book_handwritten_note_path(book, note)
       expect(response).to redirect_to(new_user_session_path)
     end
   end
@@ -33,63 +35,142 @@ RSpec.describe "HandwrittenNotes", type: :request do
       }
     end
 
-    describe "GET /books/:book_id/handwritten_note" do
-      it "初回アクセスで空のノートが作られる" do
+    describe "POST /books/:book_id/handwritten_notes" do
+      it "ノートを作成して編集画面へリダイレクトする" do
         expect {
-          get book_handwritten_note_path(book)
+          post book_handwritten_notes_path(book)
         }.to change(HandwrittenNote, :count).by(1)
-        expect(response).to have_http_status(:ok)
-        expect(HandwrittenNote.last).to have_attributes(user: user, book: book, data: {})
+        created = HandwrittenNote.order(:id).last
+        expect(response).to redirect_to(book_handwritten_note_path(book, created))
+        expect(created).to have_attributes(user: user, book: book, data: {})
       end
 
-      it "2回目以降は既存ノートを使う" do
-        note = FactoryBot.create(:handwritten_note, user: user, book: book)
-        expect {
-          get book_handwritten_note_path(book)
-        }.not_to change(HandwrittenNote, :count)
-        expect(response.body).to include("handwritten-note-root")
-        expect(response.body).to include(book_handwritten_note_path(book))
-        expect(HandwrittenNote.order(:position, :id).first).to eq(note)
+      it "positionは既存の最大+1になる" do
+        FactoryBot.create(:handwritten_note, user: user, book: book, position: 3)
+        post book_handwritten_notes_path(book)
+        expect(HandwrittenNote.order(:id).last.position).to eq(4)
       end
 
-      it "他人の本のノートにはアクセスできない" do
-        get book_handwritten_note_path(other_book)
+      it "他人の本には作成できない" do
+        post book_handwritten_notes_path(other_book)
         expect(response).to have_http_status(:not_found)
       end
     end
 
-    describe "PATCH /books/:book_id/handwritten_note" do
+    describe "GET /books/:book_id/handwritten_notes/:id" do
+      it "編集画面を表示する" do
+        get book_handwritten_note_path(book, note)
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("handwritten-note-root")
+        expect(response.body).to include(book_handwritten_note_path(book, note))
+      end
+
+      it "他人のノートにはアクセスできない" do
+        get book_handwritten_note_path(other_book, other_note)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    describe "PATCH /books/:book_id/handwritten_notes/:id" do
       it "シーンJSONを保存できる" do
-        patch book_handwritten_note_path(book), params: scene_params, as: :json
+        patch book_handwritten_note_path(book, note), params: scene_params, as: :json
         expect(response).to have_http_status(:no_content)
 
-        note = book.handwritten_notes.first
+        note.reload
         expect(note.data["elements"].first["type"]).to eq("freedraw")
         expect(note.data["appState"]["viewBackgroundColor"]).to eq("#ffffff")
       end
 
-      it "保存後に再取得すると同じシーンが返る" do
-        patch book_handwritten_note_path(book), params: scene_params, as: :json
-        get book_handwritten_note_path(book)
-        expect(response.body).to include("freedraw")
+      it "タイトルだけを保存できる" do
+        patch book_handwritten_note_path(book, note),
+              params: { handwritten_note: { title: " 第1章の構造 " } }, as: :json
+        expect(response).to have_http_status(:no_content)
+        expect(note.reload.title).to eq("第1章の構造")
+      end
+
+      it "空のタイトルはnilになる" do
+        note.update!(title: "既存タイトル")
+        patch book_handwritten_note_path(book, note),
+              params: { handwritten_note: { title: "" } }, as: :json
+        expect(note.reload.title).to be_nil
+      end
+
+      it "タイトル保存はdataを変更しない" do
+        patch book_handwritten_note_path(book, note), params: scene_params, as: :json
+        patch book_handwritten_note_path(book, note),
+              params: { handwritten_note: { title: "メモ" } }, as: :json
+        expect(note.reload.data["elements"]).to be_present
       end
 
       it "2MBを超えるdataは保存できない" do
         big_params = { handwritten_note: { data: { elements: [ { text: "a" * 2.megabytes } ] } } }
-        patch book_handwritten_note_path(book), params: big_params, as: :json
+        patch book_handwritten_note_path(book, note), params: big_params, as: :json
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.parsed_body["errors"]).to be_present
       end
 
       it "dataがオブジェクトでないと400" do
-        patch book_handwritten_note_path(book),
+        patch book_handwritten_note_path(book, note),
               params: { handwritten_note: { data: "broken" } }, as: :json
         expect(response).to have_http_status(:bad_request)
       end
 
-      it "他人の本には保存できない" do
-        patch book_handwritten_note_path(other_book), params: scene_params, as: :json
+      it "data・title以外だけのリクエストは400" do
+        patch book_handwritten_note_path(book, note),
+              params: { handwritten_note: { unknown: 1 } }, as: :json
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it "他人のノートには保存できない" do
+        patch book_handwritten_note_path(other_book, other_note), params: scene_params, as: :json
         expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    describe "PATCH /books/:book_id/handwritten_notes/:id/thumbnail" do
+      it "サムネイルを保存できる" do
+        patch thumbnail_book_handwritten_note_path(book, note),
+              params: { thumbnail: fixture_file_upload("sample.png", "image/png") }
+        expect(response).to have_http_status(:no_content)
+        expect(note.reload.thumbnail_s3).to be_attached
+      end
+
+      it "ファイルがないと400" do
+        patch thumbnail_book_handwritten_note_path(book, note)
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it "他人のノートには保存できない" do
+        patch thumbnail_book_handwritten_note_path(other_book, other_note),
+              params: { thumbnail: fixture_file_upload("sample.png", "image/png") }
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    describe "DELETE /books/:book_id/handwritten_notes/:id" do
+      it "ノートを削除して本詳細へリダイレクトする" do
+        note
+        expect {
+          delete book_handwritten_note_path(book, note)
+        }.to change(HandwrittenNote, :count).by(-1)
+        expect(response).to redirect_to(book_path(book))
+      end
+
+      it "他人のノートは削除できない" do
+        other_note
+        expect {
+          delete book_handwritten_note_path(other_book, other_note)
+        }.not_to change(HandwrittenNote, :count)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    describe "本詳細画面" do
+      it "ノート一覧と追加ボタンが表示される" do
+        note.update!(title: "読書マップ")
+        get book_path(book)
+        expect(response.body).to include("handwritten-note-list")
+        expect(response.body).to include("読書マップ")
       end
     end
   end


### PR DESCRIPTION
## 概要
手書きノート機能のPhase 2(#471)。Phase 1の「1冊1ノート固定」を解除し、本ごとに複数の手書きノートをサムネイル一覧で管理できるようにする。実装プランはissueコメント参照。

## 対応
- ルーティングを単数リソースから複数形に変更(`create` / `show` / `update` / `destroy` + member `thumbnail`)
- 1冊に複数ノート。`position` 順(新規は最大+1)、タイトル付与可能
- **サムネイル**: クライアント側 `exportToBlob()`(480px PNG)で生成し、保存成功後5秒debounce+画面離脱時にアップロード → ActiveStorage/R2。サーバー側での描画なし
- **本詳細画面**: 画像リストと同様のグリッドでサムネイル一覧+「追加」タイル+削除(turbo_confirm)。ツールバーのペンアイコンは「最初のノートを開く/なければ作成」
- **タイトル編集**: エディタ画面ヘッダーの入力欄からdebounce保存(`update` に相乗り。リクエストボディ直接パース方式はPhase 1を踏襲)
- **iPhone対応**: mobile UAでは `viewModeEnabled` の読み取り専用表示(自動保存・タイトル編集は無効化)
- 添付サービスは既存 `Image#image_s3` と同じ `Rails.env.test? ? :test : :cloudflare_private_r2` パターン
- BulletがActiveStorageのattach内部の `includes(:record)` を誤検知するためtest環境でsafelistに追加

## 影響範囲
- 旧 `/books/:id/handwritten_note`(単数)ルートは廃止(内部リンクのみで外部参照なし)。Phase 1で保存したノートのデータはそのまま開ける(検証済み)
- 既存のメモ・画像機能に変更なし
- Excalidrawチャンクは引き続き手書きノート画面専用(既存ページのバンドル影響なし)

Part of #471 (Phase 2)

## Test plan
- [x] `bundle exec rubocop` → no offenses
- [x] `bundle exec brakeman -q` → 0 warnings
- [x] `npm run typecheck` / `npm run build` → エラーなし
- [x] `docker compose run --rm web-test` → 305 examples, 0 failures, 2 pending(既知)
- [x] request spec: 作成(position採番)・取得・data/title更新・サムネイル添付・削除・他ユーザー404を網羅
- [x] ブラウザ実機: ノート作成→描画→タイトル入力→自動保存(204)→サムネイル自動アップロード(R2へ204)→本詳細に一覧表示
- [x] curl検証: 2ノート目の作成・一覧表示・削除、iPhone UAで `data-view-mode="true"` + タイトルreadonly

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 手書きノートを複数管理できるようになり、一覧表示・追加・削除・個別編集ができるようになりました。
  * ノートごとのタイトル編集とサムネイル表示に対応しました。
  * 本の詳細画面で手書きノート一覧を確認できるようになりました。

* **Bug Fixes**
  * ノートの保存時に、タイトル更新やサムネイル更新がより安定して反映されるようになりました。
  * モバイル表示時の編集画面の見え方を調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->