### PR TITLE
読書戦略ボード: 締切設定とスケジュールでコツコツ読書を支援する

### DIFF
--- a/app/assets/icons/calendar-check.svg
+++ b/app/assets/icons/calendar-check.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-calendar-check" viewBox="0 0 16 16">
+  <path d="M10.854 7.146a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708 0l-1.5-1.5a.5.5 0 1 1 .708-.708L7.5 9.793l2.646-2.647a.5.5 0 0 1 .708 0"/>
+  <path d="M3.5 0a.5.5 0 0 1 .5.5V1h8V.5a.5.5 0 0 1 1 0V1h1a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V3a2 2 0 0 1 2-2h1V.5a.5.5 0 0 1 .5-.5M1 4v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V4z"/>
+</svg>

--- a/app/controllers/books/reading_schedules_controller.rb
+++ b/app/controllers/books/reading_schedules_controller.rb
@@ -1,0 +1,41 @@
+class Books::ReadingSchedulesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_book
+
+  def update
+    if @book.update(reading_schedule_params)
+      respond_to do |format|
+        format.turbo_stream do
+          render turbo_stream: turbo_stream.replace(
+            "reading_board_book_#{@book.id}",
+            partial: "reading_board/book",
+            locals: { book: @book }
+          )
+        end
+        format.html { redirect_to reading_board_path }
+      end
+    else
+      respond_to do |format|
+        format.turbo_stream do
+          flash.now[:danger] = @book.errors.full_messages.join("、")
+          render turbo_stream: turbo_stream.replace(
+            "reading_board_book_#{@book.id}",
+            partial: "reading_board/book",
+            locals: { book: @book }
+          ), status: :unprocessable_entity
+        end
+        format.html { redirect_to reading_board_path, alert: @book.errors.full_messages.join("、") }
+      end
+    end
+  end
+
+  private
+
+  def set_book
+    @book = current_user.books.find(params[:book_id])
+  end
+
+  def reading_schedule_params
+    params.expect(book: [ :target_finish_on, :current_page ])
+  end
+end

--- a/app/controllers/reading_board_controller.rb
+++ b/app/controllers/reading_board_controller.rb
@@ -1,0 +1,11 @@
+class ReadingBoardController < ApplicationController
+  before_action :authenticate_user!
+
+  def show
+    @books = current_user.books
+      .reading
+      .with_attached_book_cover_s3
+      .order(Arel.sql("target_finish_on ASC NULLS LAST"))
+      .order(:created_at)
+  end
+end

--- a/app/helpers/reading_board_helper.rb
+++ b/app/helpers/reading_board_helper.rb
@@ -1,0 +1,34 @@
+module ReadingBoardHelper
+  # 読書スケジュールの状態バッジ
+  def reading_schedule_badge(book)
+    case book.reading_schedule_status
+    when :overdue
+      days = book.days_remaining.abs
+      content_tag(:span, "#{days}日超過", class: "badge rounded-pill bg-danger")
+    when :due_today
+      content_tag(:span, "本日まで", class: "badge rounded-pill bg-warning text-dark")
+    when :on_track
+      content_tag(:span, "あと#{book.days_remaining}日", class: "badge rounded-pill bg-success")
+    else # :no_target / :finished
+      content_tag(:span, "目標日 未設定", class: "badge rounded-pill bg-secondary")
+    end
+  end
+
+  # 必要ペースの説明テキスト(算出できないときは案内文)
+  def reading_pace_text(book)
+    remaining = book.pages_remaining
+    pace = book.required_daily_pages
+
+    if book.target_finish_on.nil?
+      "目標日を決めると、1日に読むページ数の目安が出ます"
+    elsif remaining.nil?
+      "総ページ数と現在ページを入れると、必要ペースが出ます"
+    elsif remaining.zero?
+      "読了ページに到達しています 🎉"
+    elsif book.reading_schedule_status == :overdue
+      "残り#{remaining}ページ(期限超過)"
+    else
+      "残り#{remaining}ページ / #{book.days_remaining}日 → 1日#{pace}ページ"
+    end
+  end
+end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -23,6 +23,9 @@ class Book < ApplicationRecord
   validates :page,
           numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 50_560, message: ": ページ数は50560ページ以下で入力してください" },
           allow_blank: true
+  validates :current_page,
+          numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 50_560, message: ": 現在のページは50560ページ以下で入力してください" },
+          allow_nil: true
   validates :price,
           numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 1_000_000, message: ": 金額は100万円以下で指定してください" },
           allow_blank: true
@@ -48,6 +51,52 @@ class Book < ApplicationRecord
     else
       Rails.application.routes.url_helpers.rails_blob_url(book_cover_s3, only_path: false)
     end
+  end
+
+  # 読書戦略ボード用の算出メソッド群。target_finish_on / current_page /
+  # page はいずれも未設定(nil / 0)を取りうるため、常に nil 安全に扱う。
+
+  # 進捗率(0.0〜1.0)。総ページ数か現在ページが不明なら nil
+  def reading_progress_ratio
+    return nil if page.to_i <= 0 || current_page.nil?
+
+    (current_page.to_f / page).clamp(0.0, 1.0)
+  end
+
+  # 残りページ数。総ページ数か現在ページが不明なら nil
+  def pages_remaining
+    return nil if page.to_i <= 0 || current_page.nil?
+
+    [ page - current_page, 0 ].max
+  end
+
+  # 目標日までの残り日数(過ぎていれば負)。目標日未設定なら nil
+  def days_remaining(from: Date.current)
+    return nil if target_finish_on.nil?
+
+    (target_finish_on - from).to_i
+  end
+
+  # 目標日までに1日あたり何ページ読めば間に合うか。算出不能なら nil
+  def required_daily_pages(from: Date.current)
+    remaining = pages_remaining
+    days = days_remaining(from: from)
+    return nil if remaining.nil? || days.nil?
+    return remaining if days <= 0 # 当日・超過分は残り全部が必要ペース
+
+    (remaining.to_f / days).ceil
+  end
+
+  # 読書スケジュールの状態を表すシンボル
+  def reading_schedule_status(from: Date.current)
+    return :finished if finished?
+    return :no_target if target_finish_on.nil?
+
+    days = days_remaining(from: from)
+    return :overdue if days.negative?
+    return :due_today if days.zero?
+
+    :on_track
   end
 
   scope :autocomplete_title_or_author, ->(term) {

--- a/app/views/reading_board/_book.html.erb
+++ b/app/views/reading_board/_book.html.erb
@@ -1,0 +1,57 @@
+<div class="col" id="reading_board_book_<%= book.id %>">
+  <div class="card h-100 shadow-sm">
+    <div class="card-body d-flex flex-column">
+      <div class="d-flex gap-3">
+        <%= link_to book_path(book), class: "flex-shrink-0", title: book.title do %>
+          <% if book.book_cover_s3.attached? %>
+            <%= lazy_image_tag book.book_cover_s3, alt: book.title,
+                  style: "width: 56px; height: 80px; object-fit: cover; border-radius: 4px;" %>
+          <% else %>
+            <div class="d-flex align-items-center justify-content-center bg-light text-secondary rounded"
+                 style="width: 56px; height: 80px;">
+              <%= bi_icon("book", css: "is-5") %>
+            </div>
+          <% end %>
+        <% end %>
+
+        <div class="flex-grow-1 min-w-0">
+          <div class="d-flex justify-content-between align-items-start gap-2">
+            <%= link_to book.title, book_path(book),
+                  class: "fw-bold text-decoration-none text-body text-truncate d-block", title: book.title %>
+            <%= reading_schedule_badge(book) %>
+          </div>
+          <% if book.author.present? %>
+            <div class="small text-secondary text-truncate"><%= book.author %></div>
+          <% end %>
+
+          <% if (ratio = book.reading_progress_ratio) %>
+            <% percent = (ratio * 100).round %>
+            <div class="progress mt-2" role="progressbar" aria-label="読書の進捗"
+                 aria-valuenow="<%= percent %>" aria-valuemin="0" aria-valuemax="100" style="height: 6px;">
+              <div class="progress-bar bg-success" style="width: <%= percent %>%;"></div>
+            </div>
+            <div class="small text-secondary mt-1"><%= book.current_page %> / <%= book.page %> ページ（<%= percent %>%）</div>
+          <% end %>
+        </div>
+      </div>
+
+      <div class="small text-secondary mt-2"><%= reading_pace_text(book) %></div>
+
+      <%= form_with model: book, url: book_reading_schedule_path(book), method: :patch,
+            class: "row g-2 align-items-end mt-2" do |f| %>
+        <div class="col-6">
+          <%= f.label :target_finish_on, "読了目標日", class: "form-label small mb-1" %>
+          <%= f.date_field :target_finish_on, value: book.target_finish_on, class: "form-control form-control-sm" %>
+        </div>
+        <div class="col-4">
+          <%= f.label :current_page, "現在ページ", class: "form-label small mb-1" %>
+          <%= f.number_field :current_page, value: book.current_page, min: 0,
+                max: (book.page.presence || 50_560), class: "form-control form-control-sm" %>
+        </div>
+        <div class="col-2 d-grid">
+          <%= f.submit "更新", class: "btn btn-sm btn-primary" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/reading_board/show.html.erb
+++ b/app/views/reading_board/show.html.erb
@@ -1,0 +1,28 @@
+<% content_for :title, "読書戦略ボード - Bokrium" %>
+
+<div class="container my-4 my-md-5" style="max-width: 960px;">
+  <div class="d-flex align-items-center gap-2 mb-1">
+    <%= bi_icon("calendar-check", css: "is-4") %>
+    <h1 class="h4 fw-bold mb-0">読書戦略ボード</h1>
+  </div>
+  <p class="text-secondary small mb-4">
+    読書中の本に読了目標日を決めて、コツコツ読み進めましょう。締切が近い順に並びます。
+  </p>
+
+  <% if @books.any? %>
+    <div class="row row-cols-1 row-cols-md-2 g-3">
+      <%= render partial: "reading_board/book", collection: @books, as: :book %>
+    </div>
+  <% else %>
+    <div class="text-center text-secondary py-5">
+      <%= bi_icon("book", css: "is-3 mb-2") %>
+      <p class="mb-1">読書中の本がありません。</p>
+      <p class="small mb-3">本のステータスを「読書中」にすると、ここに並びます。</p>
+      <%= link_to "本棚へ", books_index_path, class: "btn btn-sm btn-outline-primary" %>
+    </div>
+  <% end %>
+
+  <div class="mt-4">
+    <%= link_to "← 本棚に戻る", books_index_path, class: "btn btn-sm btn-outline-secondary" %>
+  </div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -14,6 +14,9 @@
         { path: search_books_path, icon: "search_header", title: "書籍検索", active: current_path.starts_with?('/search') },
         { path: books_index_path, icon: "library-big", title: (user_signed_in? && current_user.books.exists? ? "本棚" : "サンプル本棚"), active: books_index_active_class.present? }
       ] %>
+      <% if user_signed_in? %>
+        <% icons << { path: reading_board_path, icon: "calendar-check", title: "読書戦略ボード", active: current_path.starts_with?('/reading_board') } %>
+      <% end %>
 
       <% icons.each do |item| %>
 <%= link_to item[:path],

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,6 +69,7 @@ Rails.application.routes.draw do
     resources :handwritten_notes, only: [ :create, :show, :update, :destroy ] do
       patch :thumbnail, on: :member
     end
+    resource :reading_schedule, only: [ :update ], controller: "books/reading_schedules"
     resource :row, only: [ :show, :edit, :update ], controller: "books/rows"
     resource :tags, only: [], controller: "books/tags" do
       post :toggle
@@ -80,6 +81,8 @@ Rails.application.routes.draw do
   end
 
   get "books/filters/filter", to: "books/tags#filter", as: :filter_books_tags
+
+  resource :reading_board, only: [ :show ], controller: "reading_board"
 
   resource :view_mode, only: [ :update ]
 

--- a/db/migrate/20260705000000_add_reading_schedule_to_books.rb
+++ b/db/migrate/20260705000000_add_reading_schedule_to_books.rb
@@ -1,0 +1,6 @@
+class AddReadingScheduleToBooks < ActiveRecord::Migration[8.1]
+  def change
+    add_column :books, :target_finish_on, :date
+    add_column :books, :current_page, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_04_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_05_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -59,11 +59,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_04_000000) do
     t.string "author"
     t.string "book_cover"
     t.datetime "created_at", null: false
+    t.integer "current_page"
     t.string "isbn"
     t.integer "page"
     t.integer "price"
     t.string "publisher"
     t.integer "status", default: 0, null: false
+    t.date "target_finish_on"
     t.string "title", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -155,4 +155,111 @@ RSpec.describe Book, type: :model do
       expect(results).not_to include(book1)
     end
   end
+
+  describe "current_page のバリデーション" do
+    it "nil を許可する" do
+      expect(build(:book, current_page: nil)).to be_valid
+    end
+
+    it "0以上の整数を許可する" do
+      expect(build(:book, current_page: 0)).to be_valid
+      expect(build(:book, current_page: 120)).to be_valid
+    end
+
+    it "負の値は無効" do
+      book = build(:book, current_page: -1)
+      expect(book).not_to be_valid
+      expect(book.errors[:current_page]).to be_present
+    end
+  end
+
+  describe "読書スケジュールの算出メソッド" do
+    describe "#reading_progress_ratio" do
+      it "総ページと現在ページから進捗率を返す" do
+        expect(build(:book, page: 200, current_page: 50).reading_progress_ratio).to eq(0.25)
+      end
+
+      it "総ページや現在ページが不明なら nil" do
+        expect(build(:book, page: nil, current_page: 50).reading_progress_ratio).to be_nil
+        expect(build(:book, page: 200, current_page: nil).reading_progress_ratio).to be_nil
+        expect(build(:book, page: 0, current_page: 10).reading_progress_ratio).to be_nil
+      end
+
+      it "現在ページが総ページを超えても 1.0 を上限にする" do
+        expect(build(:book, page: 100, current_page: 150).reading_progress_ratio).to eq(1.0)
+      end
+    end
+
+    describe "#pages_remaining" do
+      it "残りページ数を返す" do
+        expect(build(:book, page: 200, current_page: 50).pages_remaining).to eq(150)
+      end
+
+      it "読了ページを超えても 0 未満にはならない" do
+        expect(build(:book, page: 100, current_page: 150).pages_remaining).to eq(0)
+      end
+
+      it "算出不能なら nil" do
+        expect(build(:book, page: nil, current_page: 50).pages_remaining).to be_nil
+      end
+    end
+
+    describe "#days_remaining" do
+      it "目標日までの残り日数を返す" do
+        book = build(:book, target_finish_on: Date.new(2026, 7, 10))
+        expect(book.days_remaining(from: Date.new(2026, 7, 5))).to eq(5)
+      end
+
+      it "過ぎていれば負を返す" do
+        book = build(:book, target_finish_on: Date.new(2026, 7, 1))
+        expect(book.days_remaining(from: Date.new(2026, 7, 5))).to eq(-4)
+      end
+
+      it "目標日未設定なら nil" do
+        expect(build(:book, target_finish_on: nil).days_remaining).to be_nil
+      end
+    end
+
+    describe "#required_daily_pages" do
+      it "残りページを残り日数で割って切り上げる" do
+        book = build(:book, page: 200, current_page: 50, target_finish_on: Date.new(2026, 7, 12))
+        expect(book.required_daily_pages(from: Date.new(2026, 7, 5))).to eq(22) # 150 / 7 = 21.4 -> 22
+      end
+
+      it "当日・超過なら残り全ページを返す" do
+        book = build(:book, page: 200, current_page: 50, target_finish_on: Date.new(2026, 7, 5))
+        expect(book.required_daily_pages(from: Date.new(2026, 7, 5))).to eq(150)
+      end
+
+      it "算出不能なら nil" do
+        expect(build(:book, page: 200, current_page: 50, target_finish_on: nil).required_daily_pages).to be_nil
+        expect(build(:book, page: nil, current_page: nil, target_finish_on: Date.current).required_daily_pages).to be_nil
+      end
+    end
+
+    describe "#reading_schedule_status" do
+      it "目標日未設定なら :no_target" do
+        expect(build(:book, status: :reading, target_finish_on: nil).reading_schedule_status).to eq(:no_target)
+      end
+
+      it "目標日が過去なら :overdue" do
+        book = build(:book, status: :reading, target_finish_on: Date.new(2026, 7, 1))
+        expect(book.reading_schedule_status(from: Date.new(2026, 7, 5))).to eq(:overdue)
+      end
+
+      it "目標日が当日なら :due_today" do
+        book = build(:book, status: :reading, target_finish_on: Date.new(2026, 7, 5))
+        expect(book.reading_schedule_status(from: Date.new(2026, 7, 5))).to eq(:due_today)
+      end
+
+      it "目標日が未来なら :on_track" do
+        book = build(:book, status: :reading, target_finish_on: Date.new(2026, 7, 10))
+        expect(book.reading_schedule_status(from: Date.new(2026, 7, 5))).to eq(:on_track)
+      end
+
+      it "読了済みなら :finished" do
+        expect(build(:book, status: :finished, target_finish_on: Date.new(2026, 7, 1)).reading_schedule_status).to eq(:finished)
+      end
+    end
+  end
 end

--- a/spec/requests/reading_board_spec.rb
+++ b/spec/requests/reading_board_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+RSpec.describe "ReadingBoard", type: :request do
+  let(:user) { FactoryBot.create(:user) }
+  let(:other_user) { FactoryBot.create(:user) }
+
+  describe "未ログイン" do
+    it "ボード表示はログイン画面へリダイレクトされる" do
+      get reading_board_path
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+
+  describe "ログイン済み" do
+    before do
+      post user_session_path, params: { user: { email: user.email, password: user.password } }
+    end
+
+    describe "GET /reading_board" do
+      it "自分の読書中の本だけを表示する" do
+        reading = FactoryBot.create(:book, user: user, status: :reading, title: "読書中の本")
+        FactoryBot.create(:book, user: user, status: :want_to_read, title: "読みたい本")
+        FactoryBot.create(:book, user: other_user, status: :reading, title: "他人の読書中")
+
+        get reading_board_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("読書中の本")
+        expect(response.body).not_to include("読みたい本")
+        expect(response.body).not_to include("他人の読書中")
+      end
+
+      it "目標日の近い順(未設定は末尾)に並ぶ" do
+        FactoryBot.create(:book, user: user, status: :reading, title: "目標日なし", target_finish_on: nil)
+        FactoryBot.create(:book, user: user, status: :reading, title: "遠い目標", target_finish_on: Date.current + 30)
+        FactoryBot.create(:book, user: user, status: :reading, title: "近い目標", target_finish_on: Date.current + 3)
+
+        get reading_board_path
+
+        near = response.body.index("近い目標")
+        far = response.body.index("遠い目標")
+        none = response.body.index("目標日なし")
+        expect(near).to be < far
+        expect(far).to be < none
+      end
+    end
+
+    describe "PATCH /books/:book_id/reading_schedule" do
+      let(:book) { FactoryBot.create(:book, user: user, status: :reading, page: 200) }
+
+      it "目標日と現在ページを更新できる" do
+        patch book_reading_schedule_path(book), params: {
+          book: { target_finish_on: "2026-08-01", current_page: 80 }
+        }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+        expect(response).to have_http_status(:ok)
+        book.reload
+        expect(book.target_finish_on).to eq(Date.new(2026, 8, 1))
+        expect(book.current_page).to eq(80)
+      end
+
+      it "現在ページが不正なら 422 を返す" do
+        patch book_reading_schedule_path(book), params: {
+          book: { current_page: -5 }
+        }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(book.reload.current_page).to be_nil
+      end
+
+      it "他ユーザーの本は更新できない(404)" do
+        others = FactoryBot.create(:book, user: other_user, status: :reading)
+        patch book_reading_schedule_path(others), params: { book: { current_page: 10 } }
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

積ん読を防ぎ、限られた時間でもコツコツ読み進めて読了することを支援する **読書戦略ボード** を追加する。読書中の本に「読了目標日」と「現在ページ」を設定し、締切が近い順に並べて、1日あたりに読むべきページ数(必要ペース)を俯瞰できる。

## 対応

- **マイグレーション**: `books` に `target_finish_on:date` / `current_page:integer` を追加(いずれも nullable)
- **Book モデル**: nil 安全な算出メソッドを追加
  - `reading_progress_ratio`(進捗率 0.0〜1.0)/ `pages_remaining` / `days_remaining` / `required_daily_pages`(必要ペース)/ `reading_schedule_status`(未設定・超過・本日・順調・読了)
  - `current_page` の数値バリデーション(0以上, nil 許可)
- **`ReadingBoardController#show`**: `current_user` の読書中の本を `target_finish_on` 昇順(未設定は末尾)で表示
- **`Books::ReadingSchedulesController#update`**: 目標日・現在ページを Turbo Stream で更新(カードだけ差し替え、ページ遷移なし)
- **画面**: `/reading_board`(進捗バー・残り日数バッジ・必要ペース・インライン更新フォーム・空状態)
- **導線**: ヘッダーナビに読書戦略ボードのアイコン(ログイン時のみ)

## 影響範囲

- `books` テーブルにカラム2つ追加(既存データは nil のまま影響なし)
- `Book` モデルにメソッド追加(既存の挙動は変更なし)
- 新規ルート `/reading_board`、`/books/:id/reading_schedule`
- ヘッダー(`shared/_header.html.erb`)にナビ項目を1つ追加
- 既存のステータス機能・本詳細は変更なし

## Test plan

- [x] `bundle exec rubocop`(変更ファイル: offense なし)
- [x] `bundle exec brakeman -q --no-pager`(0 warnings)
- [x] `npm run typecheck`
- [x] `docker compose run --rm web-test`(331 examples, 0 failures, 2 pending=WebAuthn)
- [x] モデルspec: 進捗率・残りページ・残り日数・必要ペース・状態判定・バリデーション
- [x] リクエストspec: 認可(未ログイン→リダイレクト / 他ユーザーの本は404)、読書中のみ表示、締切順の並び、目標日・現在ページ更新、不正値で422
- [ ] iPad/ブラウザでの目視確認(ボード表示・インライン更新の体感)は後続で

Closes #487

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 読書戦略ボードを追加し、読書中の本の一覧、進捗、残りページ、目標完了までの目安を表示できるようになりました。
  * 各本ごとに読了目標日と現在ページを更新できるようになりました。
  * ヘッダーから読書戦略ボードへ移動できるようになりました。

* **改善**
  * 読書進捗に応じたバッジや案内文を表示し、状況がより分かりやすくなりました。

* **バグ修正**
  * 入力値の検証を強化し、不正な現在ページの保存を防止しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->