### PR TITLE
本詳細のタグ付けを非同期化し、モーダルを閉じずに複数タグをまとめて操作できるようにする

### DIFF
--- a/app/controllers/books/tags_controller.rb
+++ b/app/controllers/books/tags_controller.rb
@@ -3,8 +3,25 @@ class Books::TagsController < ApplicationController
   before_action :set_book, only: [ :toggle ]
 
   def toggle
-    BookTagToggleService.new(book: @book, user: current_user, tag_id: params[:tag_id], flash: flash).call
-    redirect_back fallback_location: @book
+    respond_to do |format|
+      format.turbo_stream do
+        # 非同期トグル: フラッシュに頼らず、押されたタグと本詳細のバッジ一覧だけを差し替える。
+        # サーバー応答で状態が確定するため、楽観的更新のロールバックは不要(常に整合)。
+        BookTagToggleService.new(book: @book, user: current_user, tag_id: params[:tag_id]).call
+        @tag = current_user.user_tags.find_by(id: params[:tag_id])
+        @book.user_tags.reload
+
+        if @tag
+          render :toggle
+        else
+          head :unprocessable_content
+        end
+      end
+      format.html do
+        BookTagToggleService.new(book: @book, user: current_user, tag_id: params[:tag_id], flash: flash).call
+        redirect_back fallback_location: @book
+      end
+    end
   end
 
   def filter

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -89,7 +89,7 @@
       </div>
 
       <!-- タグ -->
-      <div class="px-1 pt-1">
+      <div class="px-1 pt-1" id="book_tag_badges_<%= @book.id %>">
         <%= render "tags/tag_badge_list", book: @book %>
       </div>
       <!-- 手書きノートリスト -->

--- a/app/views/books/tags/toggle.turbo_stream.erb
+++ b/app/views/books/tags/toggle.turbo_stream.erb
@@ -1,0 +1,9 @@
+<%= turbo_stream.replace "book_#{@book.id}_tag_#{@tag.id}" do %>
+  <%= render "tags/tag_select_button", book: @book, tag: @tag %>
+<% end %>
+
+<%= turbo_stream.replace "book_tag_badges_#{@book.id}" do %>
+  <div class="px-1 pt-1" id="book_tag_badges_<%= @book.id %>">
+    <%= render "tags/tag_badge_list", book: @book %>
+  </div>
+<% end %>

--- a/app/views/tags/_tag_modals.html.erb
+++ b/app/views/tags/_tag_modals.html.erb
@@ -7,16 +7,9 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="閉じる"></button>
       </div>
       <div class="modal-body">
-        <div class="d-flex flex-wrap m-3 gap-2">
+        <div class="d-flex flex-wrap m-3 gap-2" id="tag_select_list_<%= book.id %>">
           <% if user_tags.present? %>
-            <% user_tags.each do |tag| %>
-              <% selected = book.book_tag_assignments.exists?(user_tag_id: tag.id) %>
-              <%= button_to toggle_book_tags_path(book, tag_id: tag.id), method: :post,
-                  class: "badge rounded-pill border-0 #{selected ? 'selected-tag' : 'unselected-tag'}",
-                  style: "background-color: #{tag.color.presence || '#6c757d'};" do %>
-                <%= tag.name %>
-              <% end %>
-            <% end %>
+            <%= render partial: "tags/tag_select_button", collection: user_tags, as: :tag, locals: { book: book } %>
           <% end %>
         </div>
         <hr>

--- a/app/views/tags/_tag_select_button.html.erb
+++ b/app/views/tags/_tag_select_button.html.erb
@@ -1,0 +1,8 @@
+<% selected = book.book_tag_assignments.exists?(user_tag_id: tag.id) %>
+<span id="book_<%= book.id %>_tag_<%= tag.id %>" class="d-inline-block">
+  <%= button_to toggle_book_tags_path(book, tag_id: tag.id), method: :post,
+      class: "badge rounded-pill border-0 #{selected ? 'selected-tag' : 'unselected-tag'}",
+      style: "background-color: #{tag.color.presence || '#6c757d'};" do %>
+    <%= tag.name %>
+  <% end %>
+</span>

--- a/spec/requests/books/tags_controller_spec.rb
+++ b/spec/requests/books/tags_controller_spec.rb
@@ -15,6 +15,38 @@ RSpec.describe "Books::TagsController", type: :request do
       post toggle_book_tags_path(book_id: book.id), params: { tag_id: user_tag.id }
       expect(response).to redirect_to(book_path(book))
     end
+
+    context "Turbo Stream リクエスト" do
+      let(:turbo_headers) { { "Accept" => "text/vnd.turbo-stream.html" } }
+
+      it "リダイレクトせず Turbo Stream で応答すること" do
+        post toggle_book_tags_path(book_id: book.id), params: { tag_id: user_tag.id }, headers: turbo_headers
+        expect(response).to have_http_status(:ok)
+        expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+        expect(response.body).to include("book_#{book.id}_tag_#{user_tag.id}")
+        expect(response.body).to include("book_tag_badges_#{book.id}")
+      end
+
+      it "未付与のタグを付与できること" do
+        expect {
+          post toggle_book_tags_path(book_id: book.id), params: { tag_id: user_tag.id }, headers: turbo_headers
+        }.to change { book.reload.user_tags.count }.by(1)
+        expect(response.body).to include(user_tag.name)
+      end
+
+      it "付与済みのタグを解除できること" do
+        create(:book_tag_assignment, book: book, user_tag: user_tag, user: user)
+        expect {
+          post toggle_book_tags_path(book_id: book.id), params: { tag_id: user_tag.id }, headers: turbo_headers
+        }.to change { book.reload.user_tags.count }.by(-1)
+      end
+
+      it "他ユーザーの本には付与できないこと(404)" do
+        others_book = create(:book, user: create(:user))
+        post toggle_book_tags_path(book_id: others_book.id), params: { tag_id: user_tag.id }, headers: turbo_headers
+        expect(response).to have_http_status(:not_found)
+      end
+    end
   end
 
   describe "GET /books/filters/filter" do


### PR DESCRIPTION
## 概要

本詳細(`books/:id`)のタグ選択モーダルで、タグを1つ付け外しするたびにページ全体がリロードされ、モーダルが閉じてしまう問題を解消する。**Turbo Stream で非同期化し、モーダルを開いたまま複数タグを連続で追加・削除できる**ようにする。

## 対応

- **`Books::TagsController#toggle`** を `turbo_stream` / `html` の両対応に変更
  - `turbo_stream`: `redirect_back` をやめ、押されたタグボタンと本詳細のタグバッジ一覧だけを差し替える
  - `html`: 従来どおり `redirect_back`(フォールバック)
- **整合性**: クライアント側で楽観的に状態を変えず、サーバー応答で確定させる方式。表示は常にDBの真実と一致し、通信失敗時もロールバック不要(状態が乖離しない)
- タグ選択ボタンを `tags/_tag_select_button` パーシャルに分離(`id="book_{id}_tag_{tag_id}"` を付与)
- 本詳細のタグバッジ一覧を `id="book_tag_badges_{id}"` で囲み、差し替え可能に
- `books/tags/toggle.turbo_stream.erb` を追加

## 影響範囲

- `Books::TagsController#toggle` の応答(html フォールバックは維持、既存の同期テストはそのまま通過)
- 本詳細画面のタグ選択モーダル・タグバッジ一覧のDOM(id 付与とパーシャル分割)
- 本棚(index)のタグ**フィルタ**(`tag_toggle_controller.ts`)は対象外・変更なし
- タグの作成・編集・削除・管理モーダルは変更なし

## Test plan

- [x] `bundle exec rubocop`(248 files, offense なし)
- [x] `bundle exec brakeman -q --no-pager`(0 warnings)
- [x] `npm run typecheck`
- [x] `docker compose run --rm web-test`(309 examples, 0 failures, 2 pending=WebAuthn)
- [x] リクエストspec: 既存の html リダイレクト維持、turbo_stream 応答(200/メディアタイプ)、付与・解除、他ユーザーの本は404
- [ ] ブラウザでの目視確認(モーダルを開いたまま複数タグを連続トグル→即時反映、リロードなし)は後続で

Closes #488

🤖 Generated with [Claude Code](https://claude.com/claude-code)
