### PR TITLE
読書戦略ボードにロードマップviewを追加する(開始日→目標日の時間軸バー)

### DIFF
--- a/app/assets/icons/calendar-range.svg
+++ b/app/assets/icons/calendar-range.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-calendar-range" viewBox="0 0 16 16">
+  <path d="M9 7a1 1 0 0 1 1-1h5v2h-5a1 1 0 0 1-1-1M1 9h4a1 1 0 0 1 0 2H1z"/>
+  <path d="M3.5 0a.5.5 0 0 1 .5.5V1h8V.5a.5.5 0 0 1 1 0V1h1a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V3a2 2 0 0 1 2-2h1V.5a.5.5 0 0 1 .5-.5M1 4v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V4z"/>
+</svg>

--- a/app/controllers/books/reading_schedules_controller.rb
+++ b/app/controllers/books/reading_schedules_controller.rb
@@ -36,6 +36,6 @@ class Books::ReadingSchedulesController < ApplicationController
   end
 
   def reading_schedule_params
-    params.expect(book: [ :target_finish_on, :current_page ])
+    params.expect(book: [ :target_finish_on, :current_page, :started_on ])
   end
 end

--- a/app/controllers/reading_board_controller.rb
+++ b/app/controllers/reading_board_controller.rb
@@ -1,15 +1,23 @@
 class ReadingBoardController < ApplicationController
   include ReadingBoardColumns
 
-  VIEWS = %w[list kanban].freeze
+  VIEWS = %w[list kanban roadmap].freeze
+
+  # ロードマップの時間軸ウィンドウの上限(極端な開始日・目標日でグリッドが
+  # 巨大化しないように、過去・未来それぞれをこの日数で打ち切る)
+  ROADMAP_PAST_LIMIT = 30
+  ROADMAP_FUTURE_LIMIT = 120
 
   before_action :authenticate_user!
 
   def show
     @view = resolve_view
 
-    if @view == "kanban"
+    case @view
+    when "kanban"
       @kanban_columns = Book.statuses.keys.map { |status| kanban_column(status) }
+    when "roadmap"
+      prepare_roadmap
     else
       @books = current_user.books
         .reading
@@ -27,5 +35,25 @@ class ReadingBoardController < ApplicationController
     view = VIEWS.first unless VIEWS.include?(view)
     session[:reading_board_view] = view
     view
+  end
+
+  def prepare_roadmap
+    # ロードマップは書影を描画しないため、添付のeager loadはしない
+    reading = current_user.books
+      .reading
+      .by_reading_deadline
+      .to_a
+
+    @roadmap_books = reading.select(&:target_finish_on)
+    @no_target_books = reading.reject(&:target_finish_on)
+
+    today = Date.current
+    starts = @roadmap_books.map { |book| [ book.started_on || today, book.target_finish_on ].min }
+    targets = @roadmap_books.map(&:target_finish_on)
+
+    @window_start = [ ([ today - 7 ] + starts).min, today - ROADMAP_PAST_LIMIT ].max
+    @window_end = [ ([ today + 21 ] + targets).max, today + ROADMAP_FUTURE_LIMIT ].min
+    @total_days = (@window_end - @window_start).to_i + 1
+    @today_ratio = ((today - @window_start).to_f + 0.5) / @total_days
   end
 end

--- a/app/frontend/styles/_reading_board.scss
+++ b/app/frontend/styles/_reading_board.scss
@@ -53,3 +53,91 @@
 .kanban-ghost {
   opacity: 0.4;
 }
+
+// ロードマップview
+.roadmap-scroll {
+  overflow-x: auto;
+}
+
+.roadmap-row {
+  display: grid;
+  grid-template-columns: 200px minmax(560px, 1fr);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  &--header {
+    border-bottom-color: rgba(0, 0, 0, 0.15);
+  }
+}
+
+.roadmap-label {
+  min-width: 0;
+  padding: 0.4rem 0.5rem;
+  border-right: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.roadmap-lane {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(var(--rm-days), minmax(9px, 1fr));
+  align-items: center;
+  min-height: 48px;
+
+  &--header {
+    min-height: 26px;
+    align-items: end;
+  }
+}
+
+.roadmap-tick {
+  grid-row: 1;
+  align-self: stretch;
+  display: flex;
+  align-items: flex-end;
+  padding-left: 3px;
+  border-left: 1px solid rgba(0, 0, 0, 0.08);
+  font-size: 0.68rem;
+  color: rgba(0, 0, 0, 0.45);
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.roadmap-bar {
+  grid-row: 1;
+  height: 14px;
+  border-radius: 7px;
+  opacity: 0.85;
+
+  // ウィンドウ外に続くバーは端を切って「まだ続く」ことを示す
+  &--clipped-start {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+
+  &--clipped-end {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+}
+
+// 今日の位置を示す縦線
+.roadmap-today {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background-color: rgba(220, 53, 69, 0.45);
+  pointer-events: none;
+}
+
+.roadmap-edit summary {
+  list-style: none;
+  cursor: pointer;
+
+  &::-webkit-details-marker {
+    display: none;
+  }
+}

--- a/app/helpers/reading_board_helper.rb
+++ b/app/helpers/reading_board_helper.rb
@@ -1,4 +1,32 @@
 module ReadingBoardHelper
+  # ロードマップのバーが占めるグリッド列(1始まり、endは排他的)。
+  # ウィンドウ外にはみ出す分は端に切り詰め、切り詰めたかどうかも返す
+  def roadmap_bar_columns(book, window_start:, window_end:)
+    target = book.target_finish_on
+    raw_start = [ book.started_on || Date.current, target ].min
+
+    clipped_start = raw_start < window_start
+    clipped_end = target > window_end
+    start_date = clipped_start ? window_start : raw_start
+    end_date = clipped_end ? window_end : target
+
+    {
+      start: (start_date - window_start).to_i + 1,
+      end: (end_date - window_start).to_i + 2,
+      clipped_start: clipped_start,
+      clipped_end: clipped_end
+    }
+  end
+
+  # ロードマップのバーの色(締切状態に応じる)
+  def roadmap_bar_class(book)
+    case book.reading_schedule_status
+    when :overdue then "bg-danger"
+    when :due_today then "bg-warning"
+    else "bg-success"
+    end
+  end
+
   # 読書スケジュールの状態バッジ
   def reading_schedule_badge(book)
     case book.reading_schedule_status

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -2,6 +2,7 @@ class Book < ApplicationRecord
   include PgSearch::Model
   include UploadValidations
   before_validation :normalize_isbn
+  before_save :record_started_on_when_reading
 
   belongs_to :user
   has_one_attached :book_cover_s3, service: :cloudflare_r2, dependent: :purge
@@ -126,5 +127,13 @@ class Book < ApplicationRecord
 
   def normalize_isbn
     self.isbn = nil if isbn.blank?
+  end
+
+  # ステータスが「読書中」になったとき、読書開始日を自動記録する。
+  # ユーザーが自分で設定・編集した値は上書きしない
+  def record_started_on_when_reading
+    return unless will_save_change_to_status? && reading?
+
+    self.started_on ||= Date.current
   end
 end

--- a/app/views/reading_board/_roadmap.html.erb
+++ b/app/views/reading_board/_roadmap.html.erb
@@ -1,0 +1,77 @@
+<% if @roadmap_books.empty? && @no_target_books.empty? %>
+  <div class="text-center text-secondary py-5">
+    <%= bi_icon("book", css: "is-3 mb-2") %>
+    <p class="mb-1">読書中の本がありません。</p>
+    <p class="small mb-3">本のステータスを「読書中」にすると、ここに並びます。</p>
+    <%= link_to "本棚へ", books_index_path, class: "btn btn-sm btn-outline-primary" %>
+  </div>
+<% else %>
+  <% if @roadmap_books.any? %>
+    <div class="roadmap-scroll border rounded">
+      <div class="roadmap-row roadmap-row--header">
+        <div class="roadmap-label"></div>
+        <div class="roadmap-lane roadmap-lane--header" style="--rm-days: <%= @total_days %>;">
+          <% (0...@total_days).step(7) do |offset| %>
+            <div class="roadmap-tick" style="grid-column: <%= offset + 1 %> / <%= [ offset + 8, @total_days + 1 ].min %>;">
+              <%= (@window_start + offset).strftime("%-m/%-d") %>
+            </div>
+          <% end %>
+          <div class="roadmap-today" style="left: <%= (@today_ratio * 100).round(2) %>%;"></div>
+        </div>
+      </div>
+
+      <% @roadmap_books.each do |book| %>
+        <% bar = roadmap_bar_columns(book, window_start: @window_start, window_end: @window_end) %>
+        <div class="roadmap-row" id="roadmap_row_<%= book.id %>">
+          <div class="roadmap-label">
+            <%= link_to book.title, book_path(book),
+                  class: "small fw-bold text-decoration-none text-body text-truncate d-block", title: book.title %>
+            <div class="d-flex align-items-center gap-2">
+              <%= reading_schedule_badge(book) %>
+              <details class="roadmap-edit">
+                <summary class="text-secondary" title="開始日・読了目標日を編集"><%= bi_icon("pencil", css: "is-7") %></summary>
+                <%= form_with model: book, url: book_reading_schedule_path(book), method: :patch,
+                      data: { turbo: false }, class: "mt-1" do |f| %>
+                  <%= f.label :started_on, "開始日", class: "form-label small mb-0" %>
+                  <%= f.date_field :started_on, value: book.started_on, class: "form-control form-control-sm mb-1" %>
+                  <%= f.label :target_finish_on, "読了目標日", class: "form-label small mb-0" %>
+                  <%= f.date_field :target_finish_on, value: book.target_finish_on, class: "form-control form-control-sm mb-1" %>
+                  <%= f.submit "更新", class: "btn btn-sm btn-primary w-100" %>
+                <% end %>
+              </details>
+            </div>
+          </div>
+          <div class="roadmap-lane" style="--rm-days: <%= @total_days %>;">
+            <div class="roadmap-bar <%= roadmap_bar_class(book) %><%= " roadmap-bar--clipped-start" if bar[:clipped_start] %><%= " roadmap-bar--clipped-end" if bar[:clipped_end] %>"
+                 style="grid-column: <%= bar[:start] %> / <%= bar[:end] %>;"
+                 title="<%= book.started_on&.strftime("%-m/%-d") || "今日" %> → <%= book.target_finish_on.strftime("%-m/%-d") %>"></div>
+            <div class="roadmap-today" style="left: <%= (@today_ratio * 100).round(2) %>%;"></div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% else %>
+    <div class="text-secondary small border rounded p-3">
+      読了目標日を設定すると、ここに時間軸のバーが表示されます。
+    </div>
+  <% end %>
+
+  <% if @no_target_books.any? %>
+    <div class="mt-4">
+      <div class="fw-bold small mb-2">目標日 未設定の読書中の本</div>
+      <div class="d-flex flex-column gap-2">
+        <% @no_target_books.each do |book| %>
+          <div class="d-flex align-items-center gap-2 border rounded px-2 py-1">
+            <%= link_to book.title, book_path(book),
+                  class: "small text-decoration-none text-body text-truncate", title: book.title %>
+            <%= form_with model: book, url: book_reading_schedule_path(book), method: :patch,
+                  data: { turbo: false }, class: "d-flex align-items-center gap-1 ms-auto" do |f| %>
+              <%= f.date_field :target_finish_on, class: "form-control form-control-sm", style: "width: auto;" %>
+              <%= f.submit "設定", class: "btn btn-sm btn-outline-primary" %>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/reading_board/show.html.erb
+++ b/app/views/reading_board/show.html.erb
@@ -1,13 +1,16 @@
 <% content_for :title, "読書戦略ボード - Bokrium" %>
 
-<div class="container my-4 my-md-5" style="max-width: <%= @view == "kanban" ? "1200px" : "960px" %>;">
+<div class="container my-4 my-md-5" style="max-width: <%= @view == "list" ? "960px" : "1200px" %>;">
   <div class="d-flex align-items-center gap-2 mb-1">
     <%= bi_icon("calendar-check", css: "is-4") %>
     <h1 class="h4 fw-bold mb-0">読書戦略ボード</h1>
   </div>
   <p class="text-secondary small mb-3">
-    <% if @view == "kanban" %>
+    <% case @view %>
+    <% when "kanban" %>
       カードをドラッグしてステータスを変更できます。
+    <% when "roadmap" %>
+      読書中の本を時間軸で俯瞰できます。バーは開始日から読了目標日まで。
     <% else %>
       読書中の本に読了目標日を決めて、コツコツ読み進めましょう。締切が近い順に並びます。
     <% end %>
@@ -22,10 +25,17 @@
           class: "btn #{@view == 'kanban' ? 'btn-secondary' : 'btn-outline-secondary'}" do %>
       <%= bi_icon("kanban", css: "is-7") %> かんばん
     <% end %>
+    <%= link_to reading_board_path(view: "roadmap"),
+          class: "btn #{@view == 'roadmap' ? 'btn-secondary' : 'btn-outline-secondary'}" do %>
+      <%= bi_icon("calendar-range", css: "is-7") %> ロードマップ
+    <% end %>
   </div>
 
-  <% if @view == "kanban" %>
+  <% case @view %>
+  <% when "kanban" %>
     <%= render "reading_board/kanban" %>
+  <% when "roadmap" %>
+    <%= render "reading_board/roadmap" %>
   <% else %>
     <%= render "reading_board/list" %>
   <% end %>

--- a/db/migrate/20260705100000_add_started_on_to_books.rb
+++ b/db/migrate/20260705100000_add_started_on_to_books.rb
@@ -1,0 +1,5 @@
+class AddStartedOnToBooks < ActiveRecord::Migration[8.1]
+  def change
+    add_column :books, :started_on, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_05_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_05_100000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -64,6 +64,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_05_000000) do
     t.integer "page"
     t.integer "price"
     t.string "publisher"
+    t.date "started_on"
     t.integer "status", default: 0, null: false
     t.date "target_finish_on"
     t.string "title", null: false

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -262,4 +262,29 @@ RSpec.describe Book, type: :model do
       end
     end
   end
+
+  describe "started_on の自動記録" do
+    it "ステータスが読書中に変わったとき今日が記録される" do
+      book = create(:book, status: :want_to_read)
+      expect {
+        book.update!(status: :reading)
+      }.to change { book.reload.started_on }.from(nil).to(Date.current)
+    end
+
+    it "すでに設定済みなら上書きしない" do
+      book = create(:book, status: :want_to_read, started_on: Date.new(2026, 7, 1))
+      book.update!(status: :reading)
+      expect(book.reload.started_on).to eq(Date.new(2026, 7, 1))
+    end
+
+    it "読書中として作成された本にも記録される" do
+      expect(create(:book, status: :reading).started_on).to eq(Date.current)
+    end
+
+    it "読書中以外への変更では記録されない" do
+      book = create(:book, status: :want_to_read)
+      book.update!(status: :finished)
+      expect(book.reload.started_on).to be_nil
+    end
+  end
 end

--- a/spec/requests/reading_board_spec.rb
+++ b/spec/requests/reading_board_spec.rb
@@ -87,6 +87,30 @@ RSpec.describe "ReadingBoard", type: :request do
       end
     end
 
+    describe "GET /reading_board (ロードマップview)" do
+      it "目標日ありの読書中の本がタイムラインに、未設定の本が導線つきで表示される" do
+        with_bar = FactoryBot.create(:book, user: user, status: :reading, title: "バーの本",
+          page: 200, current_page: 50, started_on: Date.current - 5, target_finish_on: Date.current + 10)
+        FactoryBot.create(:book, user: user, status: :reading, title: "未設定の本")
+        FactoryBot.create(:book, user: other_user, status: :reading, title: "他人の本",
+          target_finish_on: Date.current + 5)
+
+        get reading_board_path(view: "roadmap")
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("roadmap_row_#{with_bar.id}")
+        expect(response.body).to include("目標日 未設定の読書中の本", "未設定の本")
+        expect(response.body).not_to include("他人の本")
+      end
+
+      it "読書中の本がなければ空状態を表示する" do
+        get reading_board_path(view: "roadmap")
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("読書中の本がありません")
+      end
+    end
+
     describe "PATCH /books/:book_id/reading_schedule" do
       let(:book) { FactoryBot.create(:book, user: user, status: :reading, page: 200) }
 
@@ -99,6 +123,15 @@ RSpec.describe "ReadingBoard", type: :request do
         book.reload
         expect(book.target_finish_on).to eq(Date.new(2026, 8, 1))
         expect(book.current_page).to eq(80)
+      end
+
+      it "開始日を更新できる" do
+        patch book_reading_schedule_path(book), params: {
+          book: { started_on: "2026-07-01" }
+        }, headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+        expect(response).to have_http_status(:ok)
+        expect(book.reload.started_on).to eq(Date.new(2026, 7, 1))
       end
 
       it "現在ページが不正なら 422 を返す" do


### PR DESCRIPTION
## 概要

#491 Phase 2(最終フェーズ)。読書戦略ボード(`/reading_board`)に GitHub Projects の Roadmap 風の**ロードマップview**を追加する。読書中の本が時間軸グリッド上のバー(**開始日 → 読了目標日**)で表示され、いつからいつまで読むかを俯瞰できる。

## 対応

- **マイグレーション**: `books` に `started_on:date` を追加(nullable)
- **Book モデル**: ステータスが「読書中」に変わったとき `started_on` に今日を自動記録(`before_save`)。ユーザーが設定済みの値は上書きしない。読書中で作成された本にも記録
  - かんばん(Phase 1)で「読みたい→読書中」にドラッグした瞬間に開始日が入る
- **ロードマップview**(`_roadmap.html.erb`):
  - CSSグリッドのみで描画(**追加ライブラリなし**)。1列=1日
  - バーは開始日→目標日。締切状態で色分け(超過=赤 / 本日=黄 / 順調=緑)。今日の位置に縦線、週ごとの目盛り
  - ウィンドウは過去30日 / 未来120日で打ち切り。はみ出すバーは端を切って「続く」ことを表現
  - 各行の鉛筆アイコン(`<details>`、JSなし)から開始日・読了目標日をインライン編集
  - 目標日未設定の読書中の本は下部に一覧し、**その場で目標日を設定**できる(設定するとバーに昇格)
  - 既存の目標日未設定の読書中の本(started_on が nil)は今日起点でフォールバック
- viewスイッチャーに「ロードマップ」タブを追加(選択のセッション記憶は Phase 1 の仕組みに相乗り)
- `reading_schedule` の許可パラメータに `started_on` を追加
- アイコン `calendar-range` を公式Bootstrap Iconsから追加
- バーのドラッグでの日付変更は、体験を見てからのフォローアップ(issue参照)

## 影響範囲

- `books` テーブルにカラム1つ追加(既存データは nil のまま影響なし)
- `Book` に `before_save` コールバック追加(読書中への遷移時のみ作用)
- `/reading_board` のviewスイッチャー(リスト・かんばんの挙動は変更なし)
- `PATCH /books/:id/reading_schedule` が `started_on` も受け付ける
- Bullet指摘によりロードマップのクエリは書影のeager loadなし(描画しないため)

## Test plan

- [x] `bundle exec rubocop`(257 files, offense なし)
- [x] `bundle exec brakeman -q --no-pager`(0 warnings)
- [x] `npm run typecheck`
- [x] `docker compose run --rm web-test`(351 examples, 0 failures, 2 pending=WebAuthn)
- [x] モデルspec: 読書中への遷移で自動記録 / 設定済みは上書きしない / 読書中作成でも記録 / 他ステータスでは記録しない
- [x] リクエストspec: ロードマップに目標日ありの本が表示・未設定の本は導線つき一覧・他ユーザー非表示・空状態、`started_on` の更新
- [ ] ブラウザでの目視確認(バー表示・インライン編集・未設定→設定の昇格)は後続で

Closes #491

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 読書ボードに「ロードマップ」表示を追加し、読書予定を時系列で確認できるようになりました。
  * 読書中の本に開始日を表示・編集できるようになりました。

* **改善**
  * 読書を開始したタイミングで、開始日が自動で記録されるようになりました。
  * 読書予定の更新で開始日も変更できるようになりました。

* **Bug Fixes**
  * 開始日が保存されない場合がある問題を修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->