### PR TITLE
Fix: 読書戦略ボードでRakuten/Google等の外部書影が表示されない問題を修正

### DIFF
--- a/app/frontend/styles/_reading_board.scss
+++ b/app/frontend/styles/_reading_board.scss
@@ -54,6 +54,14 @@
   opacity: 0.4;
 }
 
+// リストviewの書影
+.reading-board-cover {
+  width: 56px;
+  height: 80px;
+  object-fit: cover;
+  border-radius: 4px;
+}
+
 // ロードマップview
 .roadmap-scroll {
   overflow-x: auto;

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -43,6 +43,11 @@ class Book < ApplicationRecord
     validate_upload_format(book_cover_s3, :book_cover_s3)
   end
 
+  # 表示できる書影(アップロード済み or 外部URL)があるか
+  def cover_image?
+    (book_cover_s3.attached? && book_cover_s3.key.present?) || book_cover.present?
+  end
+
   def bokrium_cover_url
     return nil unless book_cover_s3.attached? && book_cover_s3.key.present?
 

--- a/app/views/reading_board/_book.html.erb
+++ b/app/views/reading_board/_book.html.erb
@@ -3,9 +3,8 @@
     <div class="card-body d-flex flex-column">
       <div class="d-flex gap-3">
         <%= link_to book_path(book), class: "flex-shrink-0", title: book.title do %>
-          <% if book.book_cover_s3.attached? %>
-            <%= lazy_image_tag book.book_cover_s3, alt: book.title,
-                  style: "width: 56px; height: 80px; object-fit: cover; border-radius: 4px;" %>
+          <% if book.cover_image? %>
+            <%= render Books::CoverComponent.new(book: book, image_class: "reading-board-cover") %>
           <% else %>
             <div class="d-flex align-items-center justify-content-center bg-light text-secondary rounded"
                  style="width: 56px; height: 80px;">

--- a/app/views/reading_board/_kanban_card.html.erb
+++ b/app/views/reading_board/_kanban_card.html.erb
@@ -4,8 +4,8 @@
      data-book-id="<%= book.id %>">
   <div class="card-body p-2">
     <div class="d-flex gap-2">
-      <% if book.book_cover_s3.attached? %>
-        <%= lazy_image_tag book.book_cover_s3, alt: book.title, class: "kanban-card-cover flex-shrink-0" %>
+      <% if book.cover_image? %>
+        <%= render Books::CoverComponent.new(book: book, image_class: "kanban-card-cover flex-shrink-0") %>
       <% else %>
         <div class="kanban-card-cover kanban-card-cover--placeholder d-flex align-items-center justify-content-center text-secondary flex-shrink-0">
           <%= bi_icon("book", css: "is-7") %>

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -287,4 +287,14 @@ RSpec.describe Book, type: :model do
       expect(book.reload.started_on).to be_nil
     end
   end
+
+  describe "#cover_image?" do
+    it "外部URLの書影があれば true" do
+      expect(build(:book, book_cover: "https://example.com/cover.jpg").cover_image?).to be true
+    end
+
+    it "書影がなければ false" do
+      expect(build(:book, book_cover: nil).cover_image?).to be false
+    end
+  end
 end

--- a/spec/requests/reading_board_spec.rb
+++ b/spec/requests/reading_board_spec.rb
@@ -43,6 +43,15 @@ RSpec.describe "ReadingBoard", type: :request do
         expect(near).to be < far
         expect(far).to be < none
       end
+
+      it "外部URLの書影(Rakuten/Google等)も表示される" do
+        FactoryBot.create(:book, user: user, status: :reading, title: "外部書影の本",
+          book_cover: "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0000/dummy.jpg")
+
+        get reading_board_path
+
+        expect(response.body).to include("https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0000/dummy.jpg")
+      end
     end
 
     describe "GET /reading_board (かんばんview)" do
@@ -60,6 +69,15 @@ RSpec.describe "ReadingBoard", type: :request do
         end
         expect(response.body).to include("積んでる本", "読んでる本", "読み終えた本")
         expect(response.body).not_to include("他人の本")
+      end
+
+      it "外部URLの書影がカードに表示される" do
+        FactoryBot.create(:book, user: user, status: :want_to_read, title: "外部書影の本",
+          book_cover: "https://books.google.com/books/content/dummy_cover.jpg")
+
+        get reading_board_path(view: "kanban")
+
+        expect(response.body).to include("https://books.google.com/books/content/dummy_cover.jpg")
       end
 
       it "選択したviewがセッションに記憶される" do


### PR DESCRIPTION
## 概要

読書戦略ボード(リスト/かんばんview)で、Rakuten / Google / OpenBD 由来の外部URL書影(`books.book_cover`)が表示されずプレースホルダになっていた問題を修正する(#497)。

本棚は `Books::CoverComponent`(S3添付 → 外部URL → プレースホルダの3段フォールバック)で描画しているが、読書ボードの2パーシャルは `book_cover_s3.attached?` しか見ていなかった。

## 対応

- `reading_board/_book.html.erb`(リスト)と `reading_board/_kanban_card.html.erb`(かんばん)の書影描画を本棚と同じ `Books::CoverComponent` に置き換え
  - 副次効果: S3添付書影もCDN URL(`bokrium_cover_url`)配信になり、本棚と挙動が揃う(従来はblobリダイレクト経由)
- 書影が一切ない本は、現行のコンパクトなプレースホルダ(本アイコン)を維持
  - CoverComponent の no_cover プレースホルダはタイトルオーバーレイつきで、かんばんの 28x40px では潰れるため
- 書影有無の判定を `Book#cover_image?` に切り出し(`(S3添付 && key有り) || book_cover.present?`)
- リストviewの書影サイズをインラインstyleから `.reading-board-cover` クラスへ移動

## 影響範囲

- 読書戦略ボードのリスト/かんばんviewの書影描画のみ
- ロードマップviewは書影非表示のため対象外。本棚・本詳細は変更なし
- マイグレーションなし

## Test plan

- [x] `bundle exec rubocop`(259 files, offenseなし)
- [x] `bundle exec brakeman -q --no-pager`(0 warnings)
- [x] `npm run typecheck`
- [x] `docker compose run --rm web-test`(358 examples, 0 failures, 2 pending=WebAuthn)
- [x] リクエストspec: 外部URL書影の本がリスト/かんばんで `<img src>` として描画される
- [x] モデルspec: `Book#cover_image?`
- [ ] ブラウザ確認: 外部URL書影の本がリスト/かんばんに表示される(マージ後の確認環境)

Closes #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)
