### PR TITLE
Fix: Google Books APIキーのリファラー制限に対応するOrigin/Refererヘッダーを追加

### DIFF
--- a/app/services/book_apis/google_books_service.rb
+++ b/app/services/book_apis/google_books_service.rb
@@ -40,12 +40,16 @@ module BookApis
       uri = URI.parse(ENDPOINT)
       uri.query = URI.encode_www_form(params.merge(api_key_param))
 
+      req = Net::HTTP::Get.new(uri)
+      req["Origin"] = request_origin
+      req["Referer"] = request_referer
+
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
       http.open_timeout = 5
       http.read_timeout = 5
 
-      response = http.request(Net::HTTP::Get.new(uri))
+      response = http.request(req)
 
       unless response.is_a?(Net::HTTPSuccess)
         Rails.logger.warn("[GoogleBooksService] Unexpected response: #{response.code} #{response.message}")
@@ -56,6 +60,24 @@ module BookApis
 
     def self.api_key_param
       ENV["GOOGLE_BOOKS_API_KEY"].present? ? { key: ENV["GOOGLE_BOOKS_API_KEY"] } : {}
+    end
+
+    # Google CloudのAPIキーにHTTPリファラー制限をかけているため、
+    # サーバーサイドのNet::HTTPが自動付与しないOrigin/Refererを明示する(RakutenServiceと同様)
+    def self.request_origin
+      raw = ENV["APP_HOST"].to_s.strip
+      raw = "https://bokrium.com" if raw.blank?
+      normalized = raw.match?(/\Ahttps?:\/\//) ? raw : "https://#{raw}"
+      uri = URI.parse(normalized)
+      origin = +"#{uri.scheme}://#{uri.host}"
+      origin << ":#{uri.port}" if uri.port && uri.port != uri.default_port
+      origin
+    rescue URI::InvalidURIError
+      "https://bokrium.com"
+    end
+
+    def self.request_referer
+      "#{request_origin}/"
     end
 
     def self.parse_response(data, isbn)

--- a/spec/services/book_apis/google_books_service_spec.rb
+++ b/spec/services/book_apis/google_books_service_spec.rb
@@ -43,6 +43,23 @@ RSpec.describe BookApis::GoogleBooksService do
           page: 123
         })
       end
+
+      it "Origin/RefererヘッダーにAPP_HOSTを付与する(APIキーのリファラー制限対策)" do
+        allow(ENV).to receive(:[]).with("APP_HOST").and_return("https://bokrium.com")
+
+        stub_request(:get, endpoint)
+          .with(
+            query: hash_including("q" => "isbn:#{isbn}"),
+            headers: { "Origin" => "https://bokrium.com", "Referer" => "https://bokrium.com/" }
+          )
+          .to_return(status: 200, body: { items: [] }.to_json)
+
+        described_class.fetch(isbn)
+        expect(WebMock).to have_requested(:get, endpoint).with(
+          query: hash_including("q" => "isbn:#{isbn}"),
+          headers: { "Origin" => "https://bokrium.com", "Referer" => "https://bokrium.com/" }
+        )
+      end
     end
 
     context "APIキーが設定されている場合" do


### PR DESCRIPTION
## 概要

PR #500でGoogle Books APIキー対応を追加したが、Fly.ioに`GOOGLE_BOOKS_API_KEY`を設定した後も検索が`403`で失敗することが判明。キーにHTTPリファラー制限(bokrium.comのみ許可)がかかっており、サーバーサイドの`Net::HTTP`はブラウザと違い`Referer`ヘッダーを自動送信しないため、正しいキーでも弾かれていた。

## 対応

- `GoogleBooksService#request`に`Origin`/`Referer`ヘッダーを追加(`ENV["APP_HOST"]`ベース、未設定時は`https://bokrium.com`にフォールバック)
- ロジックは`RakutenService`の`request_origin`/`request_referer`と同一パターン(Rakuten側もAPIキーにリファラー制限があるため同じ対応が既に入っている)
- specにOrigin/Refererヘッダー付与を検証するケースを追加

## 影響範囲

- `app/services/book_apis/google_books_service.rb`のみ
- PR #500で追加したAPIキー対応の直接の続き(issue #499の同一原因の別側面)

## Test plan

- [x] `bundle exec rubocop`
- [x] `bundle exec brakeman -q --no-pager`
- [x] `npm run typecheck`
- [x] `docker compose run --rm web-test`(363 examples, 0 failures)

Part of #499

🤖 Generated with [Claude Code](https://claude.com/claude-code)
