### PR TITLE
Fix: 手書きノートのサムネイルがページ離脱タイミングで取り逃される問題を修正

### DIFF
--- a/app/frontend/entrypoints/components/HandwrittenNoteEditor.tsx
+++ b/app/frontend/entrypoints/components/HandwrittenNoteEditor.tsx
@@ -21,7 +21,6 @@ const PERSISTED_APP_STATE_KEYS = [
 
 const AUTOSAVE_DEBOUNCE_MS = 1200
 const TITLE_DEBOUNCE_MS = 800
-const THUMBNAIL_DEBOUNCE_MS = 5000
 const THUMBNAIL_MAX_SIZE = 480
 
 type SaveStatus = "idle" | "saving" | "saved" | "error"
@@ -31,10 +30,21 @@ interface SceneData {
   appState?: Record<string, unknown>
 }
 
+// サムネイル生成に使うシーンの静的スナップショット。
+// ライブなExcalidraw APIに依存させないことで、Turbo遷移などで
+// コンポーネントがunmountされた後でもエクスポートを完走できる
+type ExportInput = Parameters<typeof exportToBlob>[0]
+interface SceneSnapshot {
+  elements: ExportInput["elements"]
+  appState: ExportInput["appState"]
+  files: ExportInput["files"]
+}
+
 interface Props {
   updateUrl: string
   thumbnailUrl: string
   viewMode: boolean
+  thumbnailMissing: boolean
   initialSceneData: SceneData
 }
 
@@ -49,11 +59,12 @@ export default function HandwrittenNoteEditor({
   updateUrl,
   thumbnailUrl,
   viewMode,
+  thumbnailMissing,
   initialSceneData,
 }: Props): React.JSX.Element {
   const apiRef = useRef<ExcalidrawImperativeAPI | null>(null)
   const saveTimerRef = useRef<number | null>(null)
-  const thumbnailTimerRef = useRef<number | null>(null)
+  const thumbnailSeqRef = useRef(0)
   const lastSavedMarkerRef = useRef<string | null>(null)
   const [status, setStatus] = useState<SaveStatus>("idle")
 
@@ -107,31 +118,42 @@ export default function HandwrittenNoteEditor({
 
   // サムネイルは補助情報。失敗しても本体の保存フローには影響させない
   const uploadThumbnail = useCallback(
-    async (options: { keepalive?: boolean } = {}) => {
-      const api = apiRef.current
-      if (!api) return
-      const elements = api.getSceneElements()
-      if (elements.length === 0) return
+    async (snapshot: SceneSnapshot, options: { keepalive?: boolean } = {}) => {
+      if (snapshot.elements.length === 0) return
+      const seq = ++thumbnailSeqRef.current
 
       try {
         const blob = await exportToBlob({
-          elements,
-          appState: api.getAppState(),
-          files: api.getFiles(),
+          elements: snapshot.elements,
+          appState: snapshot.appState,
+          files: snapshot.files,
           maxWidthOrHeight: THUMBNAIL_MAX_SIZE,
           mimeType: "image/png",
         })
+        // エクスポート中に新しいシーンのアップロードが始まっていたら、
+        // 古いサムネイルで上書きしないよう破棄する
+        if (seq !== thumbnailSeqRef.current) return
+
         const form = new FormData()
         form.append("thumbnail", blob, "thumbnail.png")
-        await fetch(thumbnailUrl, {
-          method: "PATCH",
-          headers: {
-            "X-CSRF-Token": csrfToken(),
-            Accept: "application/json",
-          },
-          body: form,
-          keepalive: options.keepalive ?? false,
-        })
+        const postForm = (keepalive: boolean): Promise<Response> =>
+          fetch(thumbnailUrl, {
+            method: "PATCH",
+            headers: {
+              "X-CSRF-Token": csrfToken(),
+              Accept: "application/json",
+            },
+            body: form,
+            keepalive,
+          })
+        try {
+          await postForm(options.keepalive ?? false)
+        } catch (error) {
+          // keepalive fetchはボディが64KBを超えると即時例外になる。
+          // ページがまだ生きていれば通常のfetchで再送する
+          if (!options.keepalive) throw error
+          await postForm(false)
+        }
       } catch {
         // no-op
       }
@@ -139,22 +161,23 @@ export default function HandwrittenNoteEditor({
     [thumbnailUrl]
   )
 
-  const scheduleThumbnail = useCallback(() => {
-    if (thumbnailTimerRef.current !== null) {
-      window.clearTimeout(thumbnailTimerRef.current)
-    }
-    thumbnailTimerRef.current = window.setTimeout(() => {
-      thumbnailTimerRef.current = null
-      void uploadThumbnail()
-    }, THUMBNAIL_DEBOUNCE_MS)
-  }, [uploadThumbnail])
-
   const doSave = useCallback(
     async (options: { keepalive?: boolean } = {}) => {
+      const api = apiRef.current
       const marker = sceneMarker()
-      if (marker === null || marker === lastSavedMarkerRef.current) return
+      if (!api || marker === null || marker === lastSavedMarkerRef.current)
+        return
       const scene = buildPersistedScene()
       if (!scene) return
+
+      // 保存対象と同じシーンをここで静的にキャプチャしておく。
+      // 保存完了時にはTurbo遷移でunmount済みのことがあり、
+      // その時点のAPIからは要素を取得できないため
+      const snapshot: SceneSnapshot = {
+        elements: scene.elements,
+        appState: { ...api.getAppState() },
+        files: api.getFiles(),
+      }
 
       setStatus("saving")
       try {
@@ -171,12 +194,14 @@ export default function HandwrittenNoteEditor({
         if (!response.ok) throw new Error(`save failed: ${response.status}`)
         lastSavedMarkerRef.current = marker
         setStatus("saved")
-        scheduleThumbnail()
+        // 保存が成功したシーンをそのままサムネイルにする。
+        // 別タイマーに遅延させると、発火前にページを離れたとき取り逃す
+        void uploadThumbnail(snapshot, options)
       } catch {
         setStatus("error")
       }
     },
-    [sceneMarker, buildPersistedScene, updateUrl, scheduleThumbnail]
+    [sceneMarker, buildPersistedScene, updateUrl, uploadThumbnail]
   )
 
   const flushSave = useCallback(
@@ -185,14 +210,9 @@ export default function HandwrittenNoteEditor({
         window.clearTimeout(saveTimerRef.current)
         saveTimerRef.current = null
       }
-      if (thumbnailTimerRef.current !== null) {
-        window.clearTimeout(thumbnailTimerRef.current)
-        thumbnailTimerRef.current = null
-        void uploadThumbnail(options)
-      }
       void doSave(options)
     },
-    [doSave, uploadThumbnail]
+    [doSave]
   )
 
   // 描画中のonChangeは毎フレーム発火するため、ここでは重い処理をしない。
@@ -292,11 +312,21 @@ export default function HandwrittenNoteEditor({
       if (saveTimerRef.current !== null) {
         window.clearTimeout(saveTimerRef.current)
       }
-      if (thumbnailTimerRef.current !== null) {
-        window.clearTimeout(thumbnailTimerRef.current)
-      }
     }
   }, [viewMode, flushSave])
+
+  // 過去にアップロードを取り逃したサムネイルの自己修復。
+  // サーバー側に未添付でシーンに要素があれば、開いただけで生成して送る
+  // (閲覧専用のモバイルで開いた場合も含む)
+  useEffect(() => {
+    if (!thumbnailMissing) return
+    if (initialData.elements.length === 0) return
+    void uploadThumbnail({
+      elements: initialData.elements,
+      appState: initialData.appState,
+      files: initialData.files,
+    })
+  }, [thumbnailMissing, initialData, uploadThumbnail])
 
   const statusLabel: Record<SaveStatus, string> = {
     idle: "",

--- a/app/frontend/entrypoints/handwritten_note.tsx
+++ b/app/frontend/entrypoints/handwritten_note.tsx
@@ -23,6 +23,7 @@ function mountHandwrittenNote(): void {
   const thumbnailUrl = element.dataset.thumbnailUrl
   if (!updateUrl || !thumbnailUrl) return
   const viewMode = element.dataset.viewMode === "true"
+  const thumbnailMissing = element.dataset.thumbnailMissing === "true"
 
   let initialSceneData = {}
   const dataScript = document.querySelector("#handwritten-note-data")
@@ -41,6 +42,7 @@ function mountHandwrittenNote(): void {
       updateUrl={updateUrl}
       thumbnailUrl={thumbnailUrl}
       viewMode={viewMode}
+      thumbnailMissing={thumbnailMissing}
       initialSceneData={initialSceneData}
     />
   )

--- a/app/views/handwritten_notes/show.html.erb
+++ b/app/views/handwritten_notes/show.html.erb
@@ -23,7 +23,8 @@
        class="handwritten-note-canvas border rounded shadow-sm"
        data-update-url="<%= book_handwritten_note_path(@book, @handwritten_note) %>"
        data-thumbnail-url="<%= thumbnail_book_handwritten_note_path(@book, @handwritten_note) %>"
-       data-view-mode="<%= mobile? %>"></div>
+       data-view-mode="<%= mobile? %>"
+       data-thumbnail-missing="<%= !@handwritten_note.thumbnail_s3.attached? %>"></div>
 
   <script type="application/json" id="handwritten-note-data">
     <%= raw({ data: @handwritten_note.data }.to_json) %>

--- a/spec/requests/handwritten_notes_spec.rb
+++ b/spec/requests/handwritten_notes_spec.rb
@@ -65,6 +65,17 @@ RSpec.describe "HandwrittenNotes", type: :request do
         expect(response.body).to include(book_handwritten_note_path(book, note))
       end
 
+      it "サムネイル未添付ならdata-thumbnail-missingがtrueになる" do
+        get book_handwritten_note_path(book, note)
+        expect(response.body).to include('data-thumbnail-missing="true"')
+      end
+
+      it "サムネイル添付済みならdata-thumbnail-missingがfalseになる" do
+        note.thumbnail_s3.attach(fixture_file_upload("sample.png", "image/png"))
+        get book_handwritten_note_path(book, note)
+        expect(response.body).to include('data-thumbnail-missing="false"')
+      end
+
       it "他人のノートにはアクセスできない" do
         get book_handwritten_note_path(other_book, other_note)
         expect(response).to have_http_status(:not_found)


### PR DESCRIPTION
## 概要

手書きノートを書いても、本詳細ページのカードにサムネイルが反映されないことがある問題を修正する(#502)。

サムネイルは「シーン保存成功 → 5秒デバウンス → `exportToBlob` → PATCH」というクライアント側フローで生成されるため、描いてから約6.2秒以内にページを離れるとアップロードが行われなかった。特に**タブを閉じる・アプリを切り替えるなどの完全離脱**では、`pagehide` の keepalive fetch を待たずに非同期の `exportToBlob` ごと破棄され、サムネイルが永久に欠落する(描画データ自体は同期ディスパッチされる keepalive JSON で保存されるため、「ノートの中身はあるのにカードだけ白い」状態になる)。ローカルで再現確認済み。

## 対応

- **サムネイル生成を保存成功直後に移動**: 保存時に同期キャプチャしたシーンスナップショット(elements / appState / files)から生成する。ライブな Excalidraw API に依存しないため、Turbo遷移でコンポーネントが unmount された後でもエクスポートが完走する
- **5秒の追加デバウンスと専用タイマーを廃止**: 保存自体が1.2秒デバウンス済みで、480px PNG のエクスポートは軽量。タイマー発火前の離脱による取り逃しがなくなる
- **自己修復**: サーバー側にサムネイル未添付でシーンに要素がある場合、ノートを開いただけで生成・アップロードする(`data-thumbnail-missing` をビューから渡す)。**過去に取り逃した既存ノートも、次に開いた時点で直る**。閲覧専用のモバイル表示でも動く
- **keepalive の64KB制限対策**: keepalive fetch が即時例外になった場合、ページが生きていれば通常 fetch で再送する
- 古いサムネイルが新しいものを上書きしないよう、エクスポート開始時のシーケンス番号で世代管理

残る限界: 最後のストロークから1.2秒(保存デバウンス)以内にタブを閉じた場合、その回のサムネイルは生成できないが、上記の自己修復により次にノートを開いた時点で補完される。

## 影響範囲

- 手書きノートエディタ(`HandwrittenNoteEditor.tsx` / `handwritten_note.tsx`)とその表示ビュー(`show.html.erb`)のみ
- サーバー側のコントローラ・モデル・ルーティングは変更なし

## Test plan

- [x] 再現確認(修正前): 描画→即タブクローズで、データは保存されるがサムネイルが永久欠落することを確認
- [x] 修正後(dev): サムネイル欠落状態のノートを開くだけで自己修復されることを確認
- [x] 修正後(dev): 描画→1.2秒以内に「本の詳細へ」で離脱しても、保存とサムネイル添付が完了することを確認
- [x] 修正後(本番相当アセット `NODE_ENV=production bin/vite build`): 自己修復パスで正しいPNGが生成・添付されることを確認
- [x] `bundle exec rubocop` / `bundle exec brakeman -q` / `npm run typecheck`
- [x] `docker compose run --rm web-test`(363 examples, 0 failures)+ show画面の `data-thumbnail-missing` 属性のrequest spec追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 手書きノートのサムネイル生成が、保存後に即時反映されるようになりました。
  * 画面遷移中でもサムネイルの送信が完了しやすくなりました。

* **バグ修正**
  * サムネイル更新の競合や上書きミスを防ぎ、より安定して表示されるよう改善しました。
  * サムネイルが未作成の場合でも、自動で再生成されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->