### PR TITLE
Fix: 本棚一覧で表紙画像blobのN+1クエリが発生している問題を修正

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -132,7 +132,7 @@ class BooksController < ApplicationController
 
   def set_book_with_associations
     @book = current_user.books
-            .includes(:user_tags, { images: :image_s3_attachment }, :book_cover_s3_attachment)
+            .includes(:user_tags, { images: { image_s3_attachment: :blob } }, { book_cover_s3_attachment: :blob })
             .find(params[:id])
   end
 

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -5,7 +5,9 @@ class Book < ApplicationRecord
   before_save :record_started_on_when_reading
 
   belongs_to :user
-  has_one_attached :book_cover_s3, service: :cloudflare_r2, dependent: :purge
+  has_one_attached :book_cover_s3,
+    service: (Rails.env.test? ? :test : :cloudflare_r2),
+    dependent: :purge
   has_many :memos, dependent: :destroy
   has_many :images, dependent: :destroy
   has_many :handwritten_notes, dependent: :destroy

--- a/app/presenters/books_index_presenter.rb
+++ b/app/presenters/books_index_presenter.rb
@@ -28,7 +28,7 @@ class BooksIndexPresenter
                 when "b_note"
                   @user.books.select(:id, :title, :author, :publisher)
                 else
-                  @user.books.includes(:book_cover_s3_attachment)
+                  @user.books.includes(book_cover_s3_attachment: :blob)
                 end
 
     load_user_books(user_books)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -10,6 +10,9 @@ Rails.application.configure do
     Bullet.raise         = true # raise an error if n+1 query occurs
     # ActiveStorageがattach時に内部で行うincludes(:record)をBulletが誤検知するため除外する
     Bullet.add_safelist type: :unused_eager_loading, class_name: "ActiveStorage::Attachment", association: :record
+    # blobへのアクセスはdelegate_missing_to :blob経由のためBulletが「未使用のeager load」と誤検知する
+    # (実際に使われていることはspec/requests/books_spec.rbのblobクエリ数アサーションで担保)
+    Bullet.add_safelist type: :unused_eager_loading, class_name: "ActiveStorage::Attachment", association: :blob
   end
 
   # Settings specified here will take precedence over those in config/application.rb.
@@ -62,3 +65,7 @@ Rails.application.configure do
   # Raise error when a before_action's only/except options reference missing actions.
   config.action_controller.raise_on_missing_callback_actions = true
 end
+
+Rails.application.routes.default_url_options = {
+  host: "www.example.com"
+}

--- a/spec/requests/books_spec.rb
+++ b/spec/requests/books_spec.rb
@@ -12,6 +12,34 @@ RSpec.describe "Books", type: :request do
     }
   end
 
+  describe "GET /books" do
+    it "表紙付きの本を並べてもblobのN+1クエリが発生しない" do
+      5.times do |i|
+        book = create(:book, user: user, title: "表紙つきの本#{i}")
+        book.book_cover_s3.attach(
+          io: File.open(Rails.root.join("spec/fixtures/files/sample.png")),
+          filename: "sample.png",
+          content_type: "image/png"
+        )
+      end
+
+      blob_select_count = 0
+      counter = lambda do |_name, _started, _finished, _id, payload|
+        next if payload[:cached]
+
+        blob_select_count += 1 if payload[:sql].to_s.match?(/SELECT.*"active_storage_blobs"/m)
+      end
+
+      ActiveSupport::Notifications.subscribed(counter, "sql.active_record") do
+        get books_path
+      end
+
+      expect(response).to have_http_status(:ok)
+      # preload済みなら表紙5冊分のblobは1クエリにまとまる（N+1なら5クエリ以上になる）
+      expect(blob_select_count).to be <= 2
+    end
+  end
+
   describe "GET /books/:id" do
     it "書籍の詳細が表示される" do
       book = create(:book, user: user, title: "詳細テスト本")


### PR DESCRIPTION
## 概要

本棚一覧(books#index / guest / explore経由のPresenter描画)で、表紙画像のActiveStorage blobがpreloadされておらず、1冊ごとにblobのSELECTが発行されるN+1を修正する。shelfビューは1ページ最大40冊のため最大40クエリの削減になる。

Closes #505

## 対応

- `BooksIndexPresenter`: `includes(:book_cover_s3_attachment)` → `includes(book_cover_s3_attachment: :blob)`(explore_controllerの既存の正しい形に統一。`with_attached_*`はvariant用関連まで余分にpreloadするため不採用)
- `BooksController#set_book_with_associations`: 画像・表紙ともにblobまでpreload
- 再発検知用request spec追加: 表紙付き5冊で一覧を描画し、blobのSELECTが2回以下であることをアサート(修正前コードでは5回になり赤くなることを確認済み)
- specで表紙添付を可能にするため `Book#book_cover_s3` のserviceをtest環境ではDiskに切替(`Image#image_s3` と同じ既存パターン)
- test環境に `routes.default_url_options` を追加(dev/prodには既にあり、testのみ欠けていた。`rails_blob_url` の描画に必要)
- Bullet safelistに `ActiveStorage::Attachment => :blob` の unused_eager_loading を追加。blobへのアクセスは `delegate_missing_to :blob` 経由のためBulletが「未使用のeager load」と誤検知する(実際は使われていることを上記specのクエリ数で担保。既存の `:record` safelistと同種の対応)

## 影響範囲

- クエリ数削減のみで描画結果・挙動は不変
- books#index(全ビューモード)/ guest本棚 / books#show
- 本番の添付サービス設定は変更なし(test環境のみDiskに切替)

## Test plan

- [x] 追加spec: 修正前コードで赤(blobクエリ5回)→修正後に緑(1回)を確認
- [x] `bundle exec rubocop`(no offenses)
- [x] `bundle exec brakeman -q --no-pager`(0 warnings)
- [x] `npm run typecheck`
- [x] `docker compose run --rm web-test`(フルスイート)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
