### PR TITLE
Improve: 書誌検索の外部API呼び出しにタイムアウト・ISBNキャッシュ・実装統一を入れる

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -136,7 +136,13 @@ class SearchController < ApplicationController
     end
   end
 
+  # ISBN→書誌情報はほぼ不変のため、ヒットした結果のみキャッシュする
+  # (未ヒットのISBNは後から流通し始めることがあるためキャッシュしない)
   def fetch_book_info(isbn)
+    cache_key = "book_info/v1/#{isbn}"
+    cached = Rails.cache.read(cache_key)
+    return cached if cached.present?
+
     result = {}
 
     APIs.each do |api|
@@ -150,7 +156,9 @@ class SearchController < ApplicationController
       break if complete?(result)
     end
 
-    result.presence
+    result = result.presence
+    Rails.cache.write(cache_key, result, expires_in: 30.days) if result
+    result
   end
 
   def complete?(data)

--- a/app/services/book_apis/google_books_service.rb
+++ b/app/services/book_apis/google_books_service.rb
@@ -14,7 +14,7 @@ module BookApis
 
       parse_response(JSON.parse(response.body), isbn)
     rescue StandardError => e
-      Rails.logger.error("[GoogleBooksService][ISBN] #{e.message}")
+      Rails.logger.error("[GoogleBooksService][ISBN] #{e.class}: #{e.message}")
       nil
     end
 
@@ -30,7 +30,7 @@ module BookApis
         total_count: data["totalItems"].to_i
       }
     rescue StandardError => e
-      Rails.logger.error("[GoogleBooksService][Title/Author] #{e.message}")
+      Rails.logger.error("[GoogleBooksService][Title/Author] #{e.class}: #{e.message}")
       blank_result
     end
 
@@ -40,16 +40,11 @@ module BookApis
       uri = URI.parse(ENDPOINT)
       uri.query = URI.encode_www_form(params.merge(api_key_param))
 
-      req = Net::HTTP::Get.new(uri)
-      req["Origin"] = request_origin
-      req["Referer"] = request_referer
-
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = true
-      http.open_timeout = 5
-      http.read_timeout = 5
-
-      response = http.request(req)
+      # Origin/RefererはAPIキーのHTTPリファラー制限用(BookApis::HttpClient参照)
+      response = HttpClient.get(uri, headers: {
+        "Origin" => HttpClient.request_origin,
+        "Referer" => HttpClient.request_referer
+      })
 
       unless response.is_a?(Net::HTTPSuccess)
         Rails.logger.warn("[GoogleBooksService] Unexpected response: #{response.code} #{response.message}")
@@ -60,24 +55,6 @@ module BookApis
 
     def self.api_key_param
       ENV["GOOGLE_BOOKS_API_KEY"].present? ? { key: ENV["GOOGLE_BOOKS_API_KEY"] } : {}
-    end
-
-    # Google CloudのAPIキーにHTTPリファラー制限をかけているため、
-    # サーバーサイドのNet::HTTPが自動付与しないOrigin/Refererを明示する(RakutenServiceと同様)
-    def self.request_origin
-      raw = ENV["APP_HOST"].to_s.strip
-      raw = "https://bokrium.com" if raw.blank?
-      normalized = raw.match?(/\Ahttps?:\/\//) ? raw : "https://#{raw}"
-      uri = URI.parse(normalized)
-      origin = +"#{uri.scheme}://#{uri.host}"
-      origin << ":#{uri.port}" if uri.port && uri.port != uri.default_port
-      origin
-    rescue URI::InvalidURIError
-      "https://bokrium.com"
-    end
-
-    def self.request_referer
-      "#{request_origin}/"
     end
 
     def self.parse_response(data, isbn)

--- a/app/services/book_apis/http_client.rb
+++ b/app/services/book_apis/http_client.rb
@@ -1,0 +1,43 @@
+module BookApis
+  # 外部書誌API(OpenBD / Rakuten / Google Books / NDL)共通のHTTP呼び出しユーティリティ。
+  # 外部の無応答でPumaスレッドを塞がないよう、全サービスに同一のタイムアウトを適用する。
+  module HttpClient
+    require "net/http"
+    require "uri"
+
+    OPEN_TIMEOUT = 5
+    READ_TIMEOUT = 5
+
+    module_function
+
+    def get(uri, headers: {})
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = uri.scheme == "https"
+      http.open_timeout = OPEN_TIMEOUT
+      http.read_timeout = READ_TIMEOUT
+
+      req = Net::HTTP::Get.new(uri)
+      headers.each { |key, value| req[key] = value }
+
+      http.request(req)
+    end
+
+    # Google Cloud・楽天のAPIキーにHTTPリファラー制限をかけているため、
+    # サーバーサイドのNet::HTTPが自動付与しないOrigin/Refererを明示する
+    def request_origin
+      raw = ENV["APP_HOST"].to_s.strip
+      raw = "https://bokrium.com" if raw.blank?
+      normalized = raw.match?(/\Ahttps?:\/\//) ? raw : "https://#{raw}"
+      uri = URI.parse(normalized)
+      origin = +"#{uri.scheme}://#{uri.host}"
+      origin << ":#{uri.port}" if uri.port && uri.port != uri.default_port
+      origin
+    rescue URI::InvalidURIError
+      "https://bokrium.com"
+    end
+
+    def request_referer
+      "#{request_origin}/"
+    end
+  end
+end

--- a/app/services/book_apis/ndl_service.rb
+++ b/app/services/book_apis/ndl_service.rb
@@ -38,13 +38,7 @@ module BookApis
       raise "Too many HTTP redirects" if limit == 0
 
       uri = URI.parse(uri_str)
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = uri.scheme == "https"
-
-      req = Net::HTTP::Get.new(uri)
-      req["User-Agent"] = "Ruby/#{RUBY_VERSION}"
-
-      res = http.request(req)
+      res = HttpClient.get(uri, headers: { "User-Agent" => "Ruby/#{RUBY_VERSION}" })
 
       case res
       when Net::HTTPSuccess

--- a/app/services/book_apis/open_bd_service.rb
+++ b/app/services/book_apis/open_bd_service.rb
@@ -8,7 +8,7 @@ module BookApis
 
     def self.fetch(isbn)
       uri = URI.parse("#{ENDPOINT}?isbn=#{isbn}")
-      response = Net::HTTP.get_response(uri)
+      response = HttpClient.get(uri)
 
       return nil unless response.is_a?(Net::HTTPSuccess)
 
@@ -25,7 +25,7 @@ module BookApis
         price: data.dig("onix", "ProductSupply", "SupplyDetail", "Price", 0, "PriceAmount")&.to_i
       }
     rescue StandardError => e
-      Rails.logger.error("[OpenBdService] #{e.message}")
+      Rails.logger.error("[OpenBdService] #{e.class}: #{e.message}")
       nil
     end
   end

--- a/app/services/book_apis/rakuten_service.rb
+++ b/app/services/book_apis/rakuten_service.rb
@@ -49,18 +49,14 @@ module BookApis
         uri = URI.parse(ENDPOINT)
         uri.query = URI.encode_www_form(default_params.merge(params).compact)
 
-        req = Net::HTTP::Get.new(uri)
-        req["Accept"] = "application/json"
-        req["Authorization"] = "Bearer #{access_key}" if access_key.present?
-        req["Origin"] = request_origin
-        req["Referer"] = request_referer
+        headers = {
+          "Accept" => "application/json",
+          "Origin" => HttpClient.request_origin,
+          "Referer" => HttpClient.request_referer
+        }
+        headers["Authorization"] = "Bearer #{access_key}" if access_key.present?
 
-        http = Net::HTTP.new(uri.host, uri.port)
-        http.use_ssl = true
-        http.open_timeout = 5
-        http.read_timeout = 5
-
-        http.request(req)
+        HttpClient.get(uri, headers: headers)
       end
 
       def default_params
@@ -120,22 +116,6 @@ module BookApis
 
       def access_key
         ENV["RAKUTEN_ACCESS_KEY"]
-      end
-
-      def request_origin
-        raw = ENV["APP_HOST"].to_s.strip
-        raw = "https://bokrium.com" if raw.blank?
-        normalized = raw.match?(/\Ahttps?:\/\//) ? raw : "https://#{raw}"
-        uri = URI.parse(normalized)
-        origin = +"#{uri.scheme}://#{uri.host}"
-        origin << ":#{uri.port}" if uri.port && uri.port != uri.default_port
-        origin
-      rescue URI::InvalidURIError
-        "https://bokrium.com"
-      end
-
-      def request_referer
-        "#{request_origin}/"
       end
     end
   end

--- a/spec/requests/search_controller_spec.rb
+++ b/spec/requests/search_controller_spec.rb
@@ -21,6 +21,43 @@ RSpec.describe "SearchController", type: :request do
     end
   end
 
+  describe "GET /search/isbn_turbo (ISBNキャッシュ)" do
+    let(:isbn) { "9784041023444" }
+    let(:book_data) do
+      {
+        title: "キャッシュテスト本",
+        author: "テスト著者",
+        publisher: "テスト出版社",
+        isbn: isbn,
+        book_cover: "https://example.com/cover.jpg"
+      }
+    end
+    let(:turbo_headers) { { "Accept" => "text/vnd.turbo-stream.html" } }
+
+    before do
+      allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache::MemoryStore.new)
+      allow(BookApis::OpenBdService).to receive(:fetch).and_return(book_data)
+      allow(BookApis::RakutenService).to receive(:fetch).and_return(nil)
+      allow(BookApis::GoogleBooksService).to receive(:fetch).and_return(nil)
+      allow(BookApis::NdlService).to receive(:fetch).and_return(nil)
+    end
+
+    it "同一ISBNの2回目以降は外部APIを呼ばない" do
+      2.times { get search_isbn_turbo_path(isbn: isbn), headers: turbo_headers }
+
+      expect(response).to have_http_status(:ok)
+      expect(BookApis::OpenBdService).to have_received(:fetch).once
+    end
+
+    it "全APIが未ヒットのISBNはキャッシュしない" do
+      allow(BookApis::OpenBdService).to receive(:fetch).and_return(nil)
+
+      2.times { get search_isbn_turbo_path(isbn: isbn), headers: turbo_headers }
+
+      expect(BookApis::OpenBdService).to have_received(:fetch).twice
+    end
+  end
+
   describe "GET /search (typeが不正 or 空クエリ)" do
     it "typeが無効なとき何も検索されない" do
       get search_books_path(type: "unknown", query: "foo")

--- a/spec/services/book_apis/google_books_service_spec.rb
+++ b/spec/services/book_apis/google_books_service_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe BookApis::GoogleBooksService do
           .with(query: hash_including("q" => "isbn:#{isbn}"))
           .to_raise(StandardError.new("エラー発生"))
 
-        expect(Rails.logger).to receive(:error).with(/\[GoogleBooksService\]\[ISBN\] エラー発生/)
+        expect(Rails.logger).to receive(:error).with(/\[GoogleBooksService\]\[ISBN\] StandardError: エラー発生/)
         expect(described_class.fetch(isbn)).to be_nil
       end
     end
@@ -167,7 +167,7 @@ RSpec.describe BookApis::GoogleBooksService do
           .with(query: hash_including("q" => query))
           .to_raise(StandardError.new("search error"))
 
-        expect(Rails.logger).to receive(:error).with(/\[GoogleBooksService\]\[Title\/Author\] search error/)
+        expect(Rails.logger).to receive(:error).with(/\[GoogleBooksService\]\[Title\/Author\] StandardError: search error/)
         expect(described_class.fetch_by_title_or_author(query)).to eq({ items: [], total_count: 0 })
       end
     end

--- a/spec/services/book_apis/http_client_spec.rb
+++ b/spec/services/book_apis/http_client_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe BookApis::HttpClient do
+  describe '.get' do
+    let(:url) { "https://example.com/api" }
+
+    it 'GETリクエストを送りレスポンスを返す' do
+      stub_request(:get, url).to_return(status: 200, body: "ok")
+
+      response = described_class.get(URI.parse(url))
+      expect(response).to be_a(Net::HTTPSuccess)
+      expect(response.body).to eq("ok")
+    end
+
+    it '指定したヘッダを付与する' do
+      stub = stub_request(:get, url)
+        .with(headers: { "Origin" => "https://bokrium.com" })
+        .to_return(status: 200, body: "")
+
+      described_class.get(URI.parse(url), headers: { "Origin" => "https://bokrium.com" })
+      expect(stub).to have_been_requested
+    end
+
+    it 'open/read timeoutを5秒に設定する' do
+      stub_request(:get, url).to_return(status: 200, body: "")
+
+      http_instances = []
+      allow(Net::HTTP).to receive(:new).and_wrap_original do |original, *args|
+        original.call(*args).tap { |http| http_instances << http }
+      end
+
+      described_class.get(URI.parse(url))
+
+      expect(http_instances.first.open_timeout).to eq(5)
+      expect(http_instances.first.read_timeout).to eq(5)
+    end
+  end
+
+  describe '.request_origin' do
+    before do
+      allow(ENV).to receive(:[]).and_call_original
+    end
+
+    it 'APP_HOST未設定なら本番ドメインを返す' do
+      allow(ENV).to receive(:[]).with("APP_HOST").and_return(nil)
+      expect(described_class.request_origin).to eq("https://bokrium.com")
+    end
+
+    it 'スキームなしのAPP_HOSTにはhttpsを補う' do
+      allow(ENV).to receive(:[]).with("APP_HOST").and_return("bokrium.com")
+      expect(described_class.request_origin).to eq("https://bokrium.com")
+    end
+
+    it '既定外ポートは維持する' do
+      allow(ENV).to receive(:[]).with("APP_HOST").and_return("http://localhost:3000")
+      expect(described_class.request_origin).to eq("http://localhost:3000")
+    end
+  end
+
+  describe '.request_referer' do
+    it 'originに/を付けた値を返す' do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("APP_HOST").and_return("bokrium.com")
+      expect(described_class.request_referer).to eq("https://bokrium.com/")
+    end
+  end
+end

--- a/spec/services/book_apis/ndl_service_spec.rb
+++ b/spec/services/book_apis/ndl_service_spec.rb
@@ -42,5 +42,11 @@ RSpec.describe BookApis::NdlService do
         page: nil
       )
     end
+
+    it 'タイムアウトした場合はハングせずnilを返す' do
+      stub_request(:get, "https://iss.ndl.go.jp/api/opensearch?isbn=#{isbn}").to_timeout
+
+      expect(described_class.fetch(isbn)).to be_nil
+    end
   end
 end

--- a/spec/services/book_apis/open_bd_service_spec.rb
+++ b/spec/services/book_apis/open_bd_service_spec.rb
@@ -1,10 +1,9 @@
 require 'rails_helper'
-require 'net/http'
 
 RSpec.describe BookApis::OpenBdService do
   describe '.fetch' do
     let(:isbn) { "9784041023444" }
-    let(:uri) { URI.parse("https://api.openbd.jp/v1/get?isbn=#{isbn}") }
+    let(:endpoint) { "https://api.openbd.jp/v1/get?isbn=#{isbn}" }
 
     context '正常なレスポンスが返ってきた場合' do
       let(:response_body) do
@@ -32,9 +31,7 @@ RSpec.describe BookApis::OpenBdService do
       end
 
       it '正しい書籍データを返す' do
-        success_response = instance_double(Net::HTTPSuccess, body: response_body)
-        allow(success_response).to receive(:is_a?).with(Net::HTTPSuccess).and_return(true)
-        allow(Net::HTTP).to receive(:get_response).with(uri).and_return(success_response)
+        stub_request(:get, endpoint).to_return(status: 200, body: response_body)
 
         result = described_class.fetch(isbn)
         expect(result).to eq({
@@ -51,9 +48,7 @@ RSpec.describe BookApis::OpenBdService do
 
     context '書籍データが見つからない場合' do
       it 'nilを返す' do
-        response = instance_double(Net::HTTPSuccess, body: [ nil ].to_json)
-        allow(response).to receive(:is_a?).with(Net::HTTPSuccess).and_return(true)
-        allow(Net::HTTP).to receive(:get_response).with(uri).and_return(response)
+        stub_request(:get, endpoint).to_return(status: 200, body: [ nil ].to_json)
 
         expect(described_class.fetch(isbn)).to be_nil
       end
@@ -61,9 +56,7 @@ RSpec.describe BookApis::OpenBdService do
 
     context 'HTTPレスポンスが失敗した場合' do
       it 'nilを返す' do
-        fail_response = instance_double(Net::HTTPInternalServerError)
-        allow(fail_response).to receive(:is_a?).with(Net::HTTPSuccess).and_return(false)
-        allow(Net::HTTP).to receive(:get_response).with(uri).and_return(fail_response)
+        stub_request(:get, endpoint).to_return(status: 500, body: "")
 
         expect(described_class.fetch(isbn)).to be_nil
       end
@@ -71,9 +64,17 @@ RSpec.describe BookApis::OpenBdService do
 
     context '例外が発生した場合' do
       it 'nilを返す' do
-        allow(Net::HTTP).to receive(:get_response).with(uri).and_raise(StandardError.new("接続失敗"))
+        stub_request(:get, endpoint).to_raise(StandardError.new("接続失敗"))
 
-        expect(Rails.logger).to receive(:error).with(/\[OpenBdService\] 接続失敗/)
+        expect(Rails.logger).to receive(:error).with(/\[OpenBdService\] StandardError: 接続失敗/)
+        expect(described_class.fetch(isbn)).to be_nil
+      end
+    end
+
+    context 'タイムアウトした場合' do
+      it 'ハングせずnilを返す' do
+        stub_request(:get, endpoint).to_timeout
+
         expect(described_class.fetch(isbn)).to be_nil
       end
     end


### PR DESCRIPTION
## 概要

書誌検索の外部API呼び出し(OpenBD / Rakuten / Google Books / NDL)を堅牢化する。OpenBD/NDLのタイムアウト欠落(外部無応答でPumaスレッドが無期限ハング)を解消し、ほぼ不変なISBN→書誌情報をキャッシュして再スキャン時の外部API呼び出しをなくす。

Closes #507

## 対応

- `BookApis::HttpClient` を新設: open/read timeout 5秒のGET + `request_origin`/`request_referer`(Google/Rakutenで逐語重複していたものを集約)
- 4サービスすべてを `HttpClient` 経由に統一(OpenBD/NDLに初めてタイムアウトが効くようになる。Google/Rakutenは従来と同値)
- `SearchController#fetch_book_info` の結果を `Rails.cache`(solid_cache)で `book_info/v1/{isbn}` キーに30日キャッシュ。ヒットした結果のみ書き込む(未流通ISBNを長期キャッシュしない)
- エラーログ書式を `#{e.class}: #{e.message}` に統一
- spec: OpenBD specをWebMockベースに書き換え(旧specは `Net::HTTP.get_response` 直モックで実装詳細に依存)、タイムアウト時のフォールバック・キャッシュのヒット/未ヒット・HttpClientの単体specを追加

## 影響範囲

- 検索結果の内容・フォールバック順序は不変
- バーコードスキャン/ISBN検索: 同一ISBNの2回目以降が外部APIを叩かなくなる
- 外部API無応答時にスレッドが最大10秒(open+read)で解放される

## Test plan

- [x] 追加spec: タイムアウト時にnilフォールバック(OpenBD/NDL)、キャッシュヒット時に外部API不呼び出し、未ヒットISBNの非キャッシュ
- [x] `bundle exec rubocop`(no offenses)
- [x] `bundle exec brakeman -q --no-pager`(0 warnings)
- [x] `npm run typecheck`
- [x] `docker compose run --rm web-test`(フルスイート)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
