### PR TITLE
Improve: メインJSバンドルからZXing/TipTap/Reactを分離して初期ロードを軽量化する

### DIFF
--- a/app/frontend/entrypoints/application.ts
+++ b/app/frontend/entrypoints/application.ts
@@ -122,6 +122,13 @@ application.register("webauthn-registration", WebauthnRegistrationController);
 window.bootstrap = bootstrap;
 
 // --- Custom JS ---
-import "./readonly_editor";
+// readonly_editor(React+TipTap)は重いため、該当要素があるページでのみ遅延読み込みする。
+// 読み込み後はモジュール自身のturbo:loadリスナーが以降の遷移を処理する
+const loadReadonlyEditorIfNeeded = () => {
+  if (document.querySelector(".readonly-editor-root")) {
+    import("./readonly_editor");
+  }
+};
+document.addEventListener("turbo:load", loadReadonlyEditorIfNeeded);
 
 export { application };

--- a/app/frontend/entrypoints/components/HandwrittenNoteEditor.tsx
+++ b/app/frontend/entrypoints/components/HandwrittenNoteEditor.tsx
@@ -6,6 +6,7 @@ import {
   exportToBlob,
 } from "@excalidraw/excalidraw"
 import "@excalidraw/excalidraw/index.css"
+import { csrfToken } from "../utils/csrf"
 
 type ExcalidrawImperativeAPI = Parameters<
   NonNullable<React.ComponentProps<typeof Excalidraw>["excalidrawAPI"]>
@@ -46,13 +47,6 @@ interface Props {
   viewMode: boolean
   thumbnailMissing: boolean
   initialSceneData: SceneData
-}
-
-function csrfToken(): string {
-  return (
-    document.querySelector<HTMLMetaElement>("meta[name='csrf-token']")
-      ?.content ?? ""
-  )
 }
 
 export default function HandwrittenNoteEditor({

--- a/app/frontend/entrypoints/controllers/barcode_result_controller.ts
+++ b/app/frontend/entrypoints/controllers/barcode_result_controller.ts
@@ -12,6 +12,7 @@
  *****************************************************/
 import { Controller } from "@hotwired/stimulus"
 import { renderStreamMessage } from "@hotwired/turbo"
+import { csrfToken } from "../utils/csrf"
 
 interface ScanEvent extends CustomEvent {
   detail: {
@@ -36,7 +37,7 @@ export default class BarcodeResultController extends Controller {
     fetch(`/search/isbn_turbo?isbn=${isbn}`, {
       headers: {
         Accept: "text/vnd.turbo-stream.html",
-        "X-CSRF-Token": this.getCsrfToken(),
+        "X-CSRF-Token": csrfToken(),
         "X-Requested-With": "XMLHttpRequest"
       },
       signal: controller.signal
@@ -65,10 +66,5 @@ export default class BarcodeResultController extends Controller {
           </turbo-stream>
         `)
       })
-  }
-
-  getCsrfToken(): string {
-    const meta = document.querySelector('meta[name="csrf-token"]') as HTMLMetaElement | null
-    return meta?.content ?? ""
   }
 }

--- a/app/frontend/entrypoints/controllers/barcode_scan_controller.ts
+++ b/app/frontend/entrypoints/controllers/barcode_scan_controller.ts
@@ -4,7 +4,8 @@
  * 使用技術: Stimulus + ZXing + Turbo Stream
  *********************************************/
 import { Controller } from "@hotwired/stimulus"
-import { BrowserMultiFormatReader, BarcodeFormat } from "@zxing/browser"
+// ZXingは重いためスキャンページ表示時にのみ動的importする(メインバンドルに含めない)
+import type { BrowserMultiFormatReader } from "@zxing/browser"
 
 export default class BarcodeScanController extends Controller {
   private static scannerStarted = false
@@ -26,11 +27,13 @@ export default class BarcodeScanController extends Controller {
     if (document.visibilityState === "hidden") this.stopCamera()
   }
 
-  connect() {
+  async connect() {
     if (BarcodeScanController.scannerStarted) return
 
     BarcodeScanController.scannerStarted = true
     this.scannedIsbns.clear()
+
+    const { BrowserMultiFormatReader, BarcodeFormat } = await import("@zxing/browser")
 
     this.reader = new BrowserMultiFormatReader()
 

--- a/app/frontend/entrypoints/controllers/book_edit_controller.ts
+++ b/app/frontend/entrypoints/controllers/book_edit_controller.ts
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { csrfToken } from "../utils/csrf"
 
 export default class BookEditController extends Controller<HTMLElement> {
   static targets = ["title", "author", "publisher"]
@@ -62,21 +63,19 @@ export default class BookEditController extends Controller<HTMLElement> {
     const titleInput = row.querySelector<HTMLInputElement>("input[name='title']")
     const authorInput = row.querySelector<HTMLInputElement>("input[name='author']")
     const publisherInput = row.querySelector<HTMLInputElement>("input[name='publisher']")
-    const csrfMeta = document.querySelector<HTMLMetaElement>("meta[name='csrf-token']")
+    const token = csrfToken()
 
-    if (!titleInput || !authorInput || !publisherInput || !csrfMeta) {
+    if (!titleInput || !authorInput || !publisherInput || !token) {
       alert("入力値の取得に失敗しました。")
       return
     }
-
-    const csrfToken = csrfMeta.getAttribute("content") ?? ""
 
     fetch(`/books/${id}/row`, {
       method: "PATCH",
       headers: {
         "Content-Type": "application/json",
         Accept: "text/vnd.turbo-stream.html",
-        "X-CSRF-Token": csrfToken
+        "X-CSRF-Token": token
       },
       body: JSON.stringify({
         book: {

--- a/app/frontend/entrypoints/controllers/kanban_column_controller.ts
+++ b/app/frontend/entrypoints/controllers/kanban_column_controller.ts
@@ -1,12 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 import { renderStreamMessage } from "@hotwired/turbo"
 import type Sortable from "sortablejs"
-
-function csrfToken(): string {
-  return (
-    document.querySelector<HTMLMetaElement>("meta[name='csrf-token']")?.content ?? ""
-  )
-}
+import { csrfToken } from "../utils/csrf"
 
 // 読書戦略ボード(かんばん)の1列。列間ドラッグでステータス変更、
 // 列内ドラッグで手動並び替え。どちらもドロップ後の列の並び(ordered_ids)を

--- a/app/frontend/entrypoints/controllers/memo_modal_controller.ts
+++ b/app/frontend/entrypoints/controllers/memo_modal_controller.ts
@@ -1,5 +1,4 @@
 import { Controller } from "@hotwired/stimulus"
-import { mountRichEditor } from "../rich_editor"
 import { prepareMemoHtmlForSave } from "../utils/memo_links"
 import { normalizeProseMirrorHtmlForSave } from "../utils/prosemirror_html"
 
@@ -40,7 +39,7 @@ export default class MemoModalController extends Controller<HTMLElement> {
     }
   }
 
-  open(event: Event) {
+  async open(event: Event) {
     if (this.shouldIgnoreOpen(event)) return
 
     if (event.type === "touchend") {
@@ -70,6 +69,8 @@ export default class MemoModalController extends Controller<HTMLElement> {
       editorRoot.dataset.initialContent = initialContent
       editorRoot.dataset.memoId = memoId
 
+      // TipTap+Reactは重いためモーダルを開くときに初めて読み込む
+      const { mountRichEditor } = await import("../rich_editor")
       mountRichEditor(editorRoot)
 
       const observer = new MutationObserver(() => {

--- a/app/frontend/entrypoints/controllers/roadmap_controller.ts
+++ b/app/frontend/entrypoints/controllers/roadmap_controller.ts
@@ -1,11 +1,6 @@
 import { Controller } from "@hotwired/stimulus"
 import { renderStreamMessage } from "@hotwired/turbo"
-
-function csrfToken(): string {
-  return (
-    document.querySelector<HTMLMetaElement>("meta[name='csrf-token']")?.content ?? ""
-  )
-}
+import { csrfToken } from "../utils/csrf"
 
 function isoDate(date: Date): string {
   const pad = (n: number) => String(n).padStart(2, "0")

--- a/app/frontend/entrypoints/controllers/webauthn_login_controller.ts
+++ b/app/frontend/entrypoints/controllers/webauthn_login_controller.ts
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus";
+import { csrfToken } from "../utils/csrf";
 
 type LoginOptionsResponse = {
   challenge: string;
@@ -79,7 +80,7 @@ export default class WebauthnLoginController extends Controller<HTMLElement> {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "X-CSRF-Token": this.getCSRFToken(),
+          "X-CSRF-Token": csrfToken(),
         },
         body: JSON.stringify(body),
       });
@@ -160,13 +161,5 @@ export default class WebauthnLoginController extends Controller<HTMLElement> {
       binary += String.fromCharCode(bytes[i]);
     }
     return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
-  }
-
-  // Helper: CSRF トークン取得
-  private getCSRFToken(): string {
-    const meta = document.querySelector<HTMLMetaElement>(
-      'meta[name="csrf-token"]'
-    );
-    return meta ? meta.content : "";
   }
 }

--- a/app/frontend/entrypoints/controllers/webauthn_registration_controller.ts
+++ b/app/frontend/entrypoints/controllers/webauthn_registration_controller.ts
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus";
+import { csrfToken } from "../utils/csrf";
 
 type RegistrationOptionsResponse = {
   challenge: string;
@@ -101,7 +102,7 @@ export default class WebauthnRegistrationController extends Controller<HTMLEleme
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "X-CSRF-Token": this.getCSRFToken(),
+          "X-CSRF-Token": csrfToken(),
         },
         body: JSON.stringify(body),
       });
@@ -194,13 +195,5 @@ export default class WebauthnRegistrationController extends Controller<HTMLEleme
       binary += String.fromCharCode(bytes[i]);
     }
     return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
-  }
-
-  // Helper: CSRF トークン取得
-  private getCSRFToken(): string {
-    const meta = document.querySelector<HTMLMetaElement>(
-      'meta[name="csrf-token"]'
-    );
-    return meta ? meta.content : "";
   }
 }

--- a/app/frontend/entrypoints/readonly_editor.tsx
+++ b/app/frontend/entrypoints/readonly_editor.tsx
@@ -37,9 +37,14 @@ export function mountReadOnlyEditor(element: HTMLElement | null): void {
   mountedRoots.set(element, root);
 }
 
-// Turbo Drive / Turbo Native / Turbo Streams 対応
-document.addEventListener("turbo:load", () => {
+function mountAllReadOnlyEditors(): void {
   document.querySelectorAll<HTMLElement>(".readonly-editor-root").forEach((el) => {
     mountReadOnlyEditor(el);
   });
-});
+}
+
+// Turbo Drive / Turbo Native / Turbo Streams 対応
+document.addEventListener("turbo:load", mountAllReadOnlyEditors);
+
+// 遅延import時はturbo:loadが発火済みのため、モジュール評価時にも即時マウントする
+mountAllReadOnlyEditors();

--- a/app/frontend/entrypoints/utils/csrf.ts
+++ b/app/frontend/entrypoints/utils/csrf.ts
@@ -1,0 +1,5 @@
+export function csrfToken(): string {
+  return (
+    document.querySelector<HTMLMetaElement>("meta[name='csrf-token']")?.content ?? ""
+  )
+}


### PR DESCRIPTION
## 概要

メインJSバンドル(全ページで読み込まれる`application.ts`)に静的importで同梱されていた重いライブラリ(ZXing / TipTap+React)を、必要になった時点で読み込むdynamic importへ移行する。あわせて7ファイルに重複していたCSRFトークン取得を`utils/csrf.ts`に集約する。

**効果(viteマニフェストから実測): 全ページ共通のeager JSペイロード 1305.1 kB → 550.9 kB(-58%、-754 kB)**

Closes #509

## 対応

- `barcode_scan_controller`: `@zxing/browser`をスキャナ接続時の`await import()`へ(型はtype-only importで維持)
- `memo_modal_controller`: `mountRichEditor`(TipTap+React)をモーダルを開く時のdynamic importへ
- `readonly_editor`(React+TipTap): `application.ts`の静的importをやめ、`.readonly-editor-root`要素があるページでのみ遅延読み込み。遅延import時はturbo:load発火済みのためモジュール評価時の即時マウントを追加(CLAUDE.mdのentrypoint規約と同じパターン)
- `utils/csrf.ts`新設: kanban_column / roadmap / barcode_result / webauthn_login / webauthn_registration / book_edit / HandwrittenNoteEditor の7ファイルの重複実装を統一
- 分割手法は既存実例(SortableJSのdynamic import・Excalidrawの専用entrypoint)に準拠

## 影響範囲

- 全ページの初期ロードが軽量化。バーコードスキャン開始・メモモーダル初回オープン・読み取り専用メモ表示時に初回のみチャンク取得が入る(以降ブラウザキャッシュ)
- 機能・挙動は不変(マニフェストでzxing/rich_editor/readonly_editorがdynamicImports側に移動したことを確認済み)

## Test plan

- [x] viteマニフェスト比較: application entryの静的importからreadonly_editor/rich_editor/zxingが消え、dynamicImportsへ移動。eager合計 1305.1→550.9 kB
- [x] `npm run typecheck`
- [x] `bundle exec rubocop` / `bundle exec brakeman -q --no-pager`(0 warnings)
- [x] `docker compose run --rm web-test`(366 examples, 0 failures — メモモーダルのsystem spec含む)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
