### PR TITLE
Improve: CSPをreport-onlyから強制モードへ移行する(インラインJSのStimulus化含む)

### DIFF
--- a/app/frontend/entrypoints/application.ts
+++ b/app/frontend/entrypoints/application.ts
@@ -67,12 +67,14 @@ document.addEventListener("turbo:frame-load", () => {
 
 // --- Stimulus Controllers ---
 import AnimationController from "./controllers/animation_controller";
+import AuthMethodController from "./controllers/auth_method_controller";
 import AutoCompleteController from "./controllers/autocomplete_controller";
 import AutoRemoveController from "./controllers/auto_remove_controller";
 import AutoSubmitController from "./controllers/auto_submit_controller";
 import BarcodeResultController from "./controllers/barcode_result_controller";
 import BarcodeScanController from "./controllers/barcode_scan_controller";
 import BookEditController from "./controllers/book_edit_controller";
+import ClipboardController from "./controllers/clipboard_controller";
 import ColumnSelectorController from "./controllers/column_selector_controller";
 import ConfirmModalController from "./controllers/confirm_modal_controller";
 import DetailCardColumnSelectorController from "./controllers/detail_card_column_selector_controller";
@@ -87,6 +89,7 @@ import ScrollTopOnClickController from "./controllers/scroll_top_on_click_contro
 import SpinnerController from "./controllers/spinner_controller";
 import SpineBookController from "./controllers/spine_book_controller";
 import TagToggleController from "./controllers/tag_toggle_controller";
+import VideoPlayController from "./controllers/video_play_controller";
 import WebauthnLoginController from "./controllers/webauthn_login_controller";
 import WebauthnRegistrationController from "./controllers/webauthn_registration_controller";
 
@@ -95,12 +98,14 @@ const application = Application.start();
 window.Stimulus = application;
 
 application.register("animation", AnimationController);
+application.register("auth-method", AuthMethodController);
 application.register("autocomplete", AutoCompleteController);
 application.register("auto-remove", AutoRemoveController);
 application.register("auto-submit", AutoSubmitController);
 application.register("barcode-result", BarcodeResultController);
 application.register("barcode-scan", BarcodeScanController);
 application.register("book-edit", BookEditController);
+application.register("clipboard", ClipboardController);
 application.register("column-selector", ColumnSelectorController);
 application.register("confirm-modal", ConfirmModalController);
 application.register("detail-card-column-selector", DetailCardColumnSelectorController);
@@ -115,6 +120,7 @@ application.register("scroll-top-on-click", ScrollTopOnClickController);
 application.register("spinner", SpinnerController);
 application.register("spine-book", SpineBookController);
 application.register("tag-toggle", TagToggleController);
+application.register("video-play", VideoPlayController);
 application.register("webauthn-login", WebauthnLoginController);
 application.register("webauthn-registration", WebauthnRegistrationController);
 
@@ -130,5 +136,21 @@ const loadReadonlyEditorIfNeeded = () => {
   }
 };
 document.addEventListener("turbo:load", loadReadonlyEditorIfNeeded);
+
+// 非同期CSS(Google Fonts等)のmedia切替。
+// CSP強制下ではlinkタグのonload属性が使えないため、JS側で行う
+// (<link media="print" data-media-onload="all"> を対象にする)
+const activateAsyncStylesheets = () => {
+  document.querySelectorAll<HTMLLinkElement>("link[data-media-onload]").forEach((link) => {
+    const targetMedia = link.dataset.mediaOnload || "all";
+    if (link.media === targetMedia) return;
+
+    const apply = () => { link.media = targetMedia; };
+    if (link.sheet) apply();
+    else link.addEventListener("load", apply, { once: true });
+  });
+};
+activateAsyncStylesheets();
+document.addEventListener("turbo:load", activateAsyncStylesheets);
 
 export { application };

--- a/app/frontend/entrypoints/controllers/auth_method_controller.ts
+++ b/app/frontend/entrypoints/controllers/auth_method_controller.ts
@@ -1,0 +1,44 @@
+import { Controller } from "@hotwired/stimulus"
+
+// 登録画面の認証方法(パスキー/パスワード)切替。
+// パスワード選択時のみパスワード欄を表示し、required属性を付け替える
+export default class AuthMethodController extends Controller<HTMLElement> {
+  static targets = [
+    "passkeyRadio",
+    "passwordRadio",
+    "passwordFields",
+    "passkeyInfo",
+    "passwordInput",
+    "passwordConfirmInput",
+  ]
+
+  declare readonly passkeyRadioTarget: HTMLInputElement
+  declare readonly passwordRadioTarget: HTMLInputElement
+  declare readonly passwordFieldsTarget: HTMLElement
+  declare readonly hasPasskeyInfoTarget: boolean
+  declare readonly passkeyInfoTarget: HTMLElement
+  declare readonly passwordInputTarget: HTMLInputElement
+  declare readonly passwordConfirmInputTarget: HTMLInputElement
+
+  connect() {
+    if (this.passkeyRadioTarget.checked) this.selectPasskey()
+  }
+
+  selectPasskey() {
+    this.passkeyRadioTarget.checked = true
+    this.passwordFieldsTarget.style.display = "none"
+    if (this.hasPasskeyInfoTarget) this.passkeyInfoTarget.style.display = "block"
+    this.passwordInputTarget.removeAttribute("required")
+    this.passwordConfirmInputTarget.removeAttribute("required")
+    this.passwordInputTarget.value = ""
+    this.passwordConfirmInputTarget.value = ""
+  }
+
+  selectPassword() {
+    this.passwordRadioTarget.checked = true
+    this.passwordFieldsTarget.style.display = "block"
+    if (this.hasPasskeyInfoTarget) this.passkeyInfoTarget.style.display = "none"
+    this.passwordInputTarget.setAttribute("required", "required")
+    this.passwordConfirmInputTarget.setAttribute("required", "required")
+  }
+}

--- a/app/frontend/entrypoints/controllers/clipboard_controller.ts
+++ b/app/frontend/entrypoints/controllers/clipboard_controller.ts
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus"
+
+// テキストをクリップボードへコピーする(共有URLコピーなど)
+export default class ClipboardController extends Controller<HTMLElement> {
+  static values = {
+    text: String,
+    message: String,
+  }
+
+  declare readonly textValue: string
+  declare readonly messageValue: string
+  declare readonly hasMessageValue: boolean
+
+  copy() {
+    navigator.clipboard.writeText(this.textValue)
+    if (this.hasMessageValue && this.messageValue) alert(this.messageValue)
+  }
+}

--- a/app/frontend/entrypoints/controllers/video_play_controller.ts
+++ b/app/frontend/entrypoints/controllers/video_play_controller.ts
@@ -1,0 +1,14 @@
+import { Controller } from "@hotwired/stimulus"
+
+// ポスター上の再生ボタン。クリックで動画を再生してボタンを隠す
+export default class VideoPlayController extends Controller<HTMLElement> {
+  static targets = ["video", "button"]
+
+  declare readonly videoTarget: HTMLVideoElement
+  declare readonly buttonTarget: HTMLElement
+
+  play() {
+    this.videoTarget.play()
+    this.buttonTarget.style.display = "none"
+  }
+}

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -7,7 +7,7 @@
             <span class="logo-welcome" title="ボクリウム">Bokrium</span>
           </h1>
 
-          <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "needs-validation", novalidate: true, id: "registration-form" }) do |f| %>
+          <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "needs-validation", novalidate: true, id: "registration-form", data: { controller: "auth-method" } }) do |f| %>
             <%= render "devise/shared/error_messages", resource: resource %>
 
             <div class="form-floating mb-3">
@@ -40,8 +40,8 @@
             <div class="mb-3">
               <label class="form-label fw-bold">認証方法を選択してください</label>
 
-              <div class="form-check p-3 border rounded mb-2 bg-light" style="cursor: pointer;" onclick="selectAuthMethod('passkey')">
-                <%= f.radio_button :register_with_passkey, "true", id: "auth_passkey", class: "form-check-input", checked: true %>
+              <div class="form-check p-3 border rounded mb-2 bg-light" style="cursor: pointer;" data-action="click->auth-method#selectPasskey">
+                <%= f.radio_button :register_with_passkey, "true", id: "auth_passkey", class: "form-check-input", checked: true, data: { auth_method_target: "passkeyRadio" } %>
                 <label class="form-check-label w-100" for="auth_passkey" style="cursor: pointer;">
                   <strong>🔑 パスキーで登録（推奨）</strong>
                   <br>
@@ -49,8 +49,8 @@
                 </label>
               </div>
 
-              <div class="form-check p-3 border rounded" style="cursor: pointer;" onclick="selectAuthMethod('password')">
-                <%= f.radio_button :register_with_passkey, "false", id: "auth_password", class: "form-check-input" %>
+              <div class="form-check p-3 border rounded" style="cursor: pointer;" data-action="click->auth-method#selectPassword">
+                <%= f.radio_button :register_with_passkey, "false", id: "auth_password", class: "form-check-input", data: { auth_method_target: "passwordRadio" } %>
                 <label class="form-check-label w-100" for="auth_password" style="cursor: pointer;">
                   <strong>🔒 パスワードで登録</strong>
                   <br>
@@ -60,13 +60,14 @@
             </div>
 
             <!-- パスワード入力欄（パスワード選択時のみ表示） -->
-            <div id="password-fields" style="display: none;">
+            <div id="password-fields" style="display: none;" data-auth-method-target="passwordFields">
               <div class="form-floating mb-3">
                 <%= f.password_field :password,
                       autocomplete: "new-password",
                       class: "form-control #{'is-invalid' if resource.errors[:password].present?}",
                       id: "floatingPassword",
-                      placeholder: t('.password') %>
+                      placeholder: t('.password'),
+                      data: { auth_method_target: "passwordInput" } %>
                 <%= f.label :password, for: "floatingPassword" do %>
                   <%= t('.password') %> <span class="text-danger">*</span>
                 <% end %>
@@ -82,7 +83,8 @@
                       autocomplete: "new-password",
                       class: "form-control #{'is-invalid' if resource.errors[:password_confirmation].present?}",
                       id: "floatingPasswordConfirmation",
-                      placeholder: t('.password_confirmation') %>
+                      placeholder: t('.password_confirmation'),
+                      data: { auth_method_target: "passwordConfirmInput" } %>
                 <%= f.label :password_confirmation, for: "floatingPasswordConfirmation" do %>
                   <%= t('.password_confirmation') %> <span class="text-danger">*</span>
                 <% end %>
@@ -95,7 +97,7 @@
             </div>
 
             <!-- パスキー選択時の説明 -->
-            <div id="passkey-info" class="alert alert-info small">
+            <div id="passkey-info" class="alert alert-info small" data-auth-method-target="passkeyInfo">
               <strong>✨ パスキーのメリット</strong>
               <ul class="mb-0 mt-1">
                 <li>パスワードを覚える必要なし</li>
@@ -120,45 +122,3 @@
     </div>
   </div>
 </div>
-
-<script>
-  function selectAuthMethod(method) {
-    const passkeyRadio = document.getElementById('auth_passkey');
-    const passwordRadio = document.getElementById('auth_password');
-    const passwordFields = document.getElementById('password-fields');
-    const passkeyInfo = document.getElementById('passkey-info');
-    const passwordInput = document.getElementById('floatingPassword');
-    const passwordConfirmInput = document.getElementById('floatingPasswordConfirmation');
-
-    if (method === 'passkey') {
-      passkeyRadio.checked = true;
-      passwordFields.style.display = 'none';
-      if (passkeyInfo) passkeyInfo.style.display = 'block';
-      passwordInput.removeAttribute('required');
-      passwordConfirmInput.removeAttribute('required');
-      passwordInput.value = '';
-      passwordConfirmInput.value = '';
-    } else {
-      passwordRadio.checked = true;
-      passwordFields.style.display = 'block';
-      if (passkeyInfo) passkeyInfo.style.display = 'none';
-      passwordInput.setAttribute('required', 'required');
-      passwordConfirmInput.setAttribute('required', 'required');
-    }
-  }
-
-  // 初期状態でパスキー選択
-  document.addEventListener('DOMContentLoaded', () => {
-    const passkeyRadio = document.getElementById('auth_passkey');
-    if (passkeyRadio && passkeyRadio.checked) {
-      selectAuthMethod('passkey');
-    }
-  });
-
-  document.addEventListener('turbo:load', () => {
-    const passkeyRadio = document.getElementById('auth_passkey');
-    if (passkeyRadio && passkeyRadio.checked) {
-      selectAuthMethod('passkey');
-    }
-  });
-</script>

--- a/app/views/guest/starter_books/_barcode_scan_video.html.erb
+++ b/app/views/guest/starter_books/_barcode_scan_video.html.erb
@@ -1,4 +1,4 @@
-<div class="barcode-scan-preview-container rounded-5 shadow-sm position-relative">
+<div class="barcode-scan-preview-container rounded-5 shadow-sm position-relative" data-controller="video-play">
   <video
     id="barcodeVideo"
     class="video-click-to-play rounded-5 w-100 d-block"
@@ -9,6 +9,7 @@
     playsinline
     poster="<%= cdn_path('barcode_scan.png') %>"
     style="background-color: black;"
+    data-video-play-target="video"
   >
 
     <source src="https://lib.bokrium.com/barcode_scan.webm" type="video/webm">
@@ -21,7 +22,8 @@
     type="button"
     class="btn btn-danger btn-lg position-absolute top-50 start-50 translate-middle shadow"
     style="z-index: 10; border-radius: 33%;"
-    onclick="document.getElementById('barcodeVideo').play(); this.style.display='none';"
+    data-video-play-target="button"
+    data-action="video-play#play"
   >
     <%= bi_icon("play-fill", css: "is-2 is-round") %>
   </button>

--- a/app/views/guest/starter_books/_memo_video.html.erb
+++ b/app/views/guest/starter_books/_memo_video.html.erb
@@ -1,5 +1,5 @@
 <div class="d-flex justify-content-center my-4">
-  <div class="video-wrapper position-relative shadow rounded overflow-hidden w-100" style="max-width: 940px;">
+  <div class="video-wrapper position-relative shadow rounded overflow-hidden w-100" style="max-width: 940px;" data-controller="video-play">
     <video
       id="starterPlayButton"
       controls
@@ -8,6 +8,7 @@
       class="rounded img-fluid w-100"
       style="display: block;"
       poster="<%= cdn_path('starter_book1_compressed.png') %>"
+      data-video-play-target="video"
       >
       <source src="https://lib.bokrium.com/starter_book1_compressed.webm" type="video/webm">
       お使いのブラウザは video に対応していません。
@@ -16,7 +17,8 @@
     type="button"
     class="btn btn-danger btn-lg position-absolute top-50 start-50 translate-middle shadow"
     style="z-index: 10; border-radius: 33%;"
-    onclick="document.getElementById('starterPlayButton').play(); this.style.display='none';"
+    data-video-play-target="button"
+    data-action="video-play#play"
   >
     <%= bi_icon("play-fill", css: "is-2 is-round") %>
   </button>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,11 +30,12 @@
     <!-- Google Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <%# onload属性はCSP強制下で使えないため、media切替はapplication.tsのactivateAsyncStylesheetsが行う %>
     <link
       href="https://fonts.googleapis.com/css2?family=Big+Shoulders+Inline:opsz,wght@10..72,700&family=Noto+Sans+JP:wght@400;600;700&display=swap"
       rel="stylesheet"
       media="print"
-      onload="this.media='all'">
+      data-media-onload="all">
     <noscript>
       <link
         href="https://fonts.googleapis.com/css2?family=Big+Shoulders+Inline:opsz,wght@10..72,700&family=Noto+Sans+JP:wght@400;600;700&display=swap"

--- a/app/views/memos/_read_only_item.html.erb
+++ b/app/views/memos/_read_only_item.html.erb
@@ -56,7 +56,10 @@
           <li>
             <button
               class="dropdown-item"
-              onclick="navigator.clipboard.writeText('<%= memo.public_url %>'); alert('共有URLをコピーしました');"
+              data-controller="clipboard"
+              data-clipboard-text-value="<%= memo.public_url %>"
+              data-clipboard-message-value="共有URLをコピーしました"
+              data-action="clipboard#copy"
             >
             <%= bi_icon("clipboard", css: "is-6 me-1") %> 共有URLをコピー
             </button>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -7,12 +7,16 @@ Rails.application.configure do
         "https://assets.bokrium.com", "https://lib.bokrium.com", "https://cdn.bokrium.com", "https://img.bokrium.com", "https://img.hanmoto.com",
         "https://books.google.com", "https://thumbnail.image.rakuten.co.jp", "https://webservice.rakuten.co.jp", "https://image.rakuten.co.jp", "https://rimg.jp"
     policy.object_src  :none
-    policy.script_src  :self, :https,  "https://assets.bokrium.com"
-    policy.style_src   :self, :https,  "https://assets.bokrium.com", "https://fonts.googleapis.com"
+    # scriptは自前オリジン+アセットCDNのみ(包括的な:httpsを許可しない)。
+    # インラインscript・インラインイベントハンドラは全廃済みのためunsafe_inline不要
+    policy.script_src  :self, "https://assets.bokrium.com"
+    # style属性・<style>ブロック(public_bookshelf等)・Turboのプログレスバーが
+    # インラインCSSを使うためunsafe_inlineを許可(script側が絞られていれば実害は限定的)
+    policy.style_src   :self, :unsafe_inline, "https://assets.bokrium.com", "https://fonts.googleapis.com"
 
     if Rails.env.development?
       script_srcs = policy.script_src + [ :unsafe_eval, "http://localhost:3036" ]
-      style_srcs = policy.style_src + [ :unsafe_inline, "http://localhost:3036" ]
+      style_srcs = (policy.style_src + [ :unsafe_inline, "http://localhost:3036" ]).uniq
       connect_srcs = Array(policy.connect_src) + [ :self, "http://localhost:3036", "ws://localhost:3036" ]
 
       policy.script_src(*script_srcs)
@@ -22,6 +26,4 @@ Rails.application.configure do
       policy.connect_src :self
     end
   end
-
-  config.content_security_policy_report_only = true
 end

--- a/spec/requests/content_security_policy_spec.rb
+++ b/spec/requests/content_security_policy_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe "Content Security Policy", type: :request do
+  it "CSPが強制モード(Report-Onlyでない)で配信される" do
+    get root_path
+
+    expect(response).to have_http_status(:ok)
+    expect(response.headers["Content-Security-Policy"]).to be_present
+    expect(response.headers["Content-Security-Policy-Report-Only"]).to be_nil
+  end
+
+  it "script-srcが自前オリジン+アセットCDNに限定されている" do
+    get root_path
+
+    script_src = response.headers["Content-Security-Policy"][/script-src [^;]*/]
+    expect(script_src).to include("'self'")
+    expect(script_src).to include("https://assets.bokrium.com")
+    expect(script_src).not_to include("https:;")
+    expect(script_src).not_to include("'unsafe-inline'")
+  end
+end


### PR DESCRIPTION
## 概要

CSPを`report_only`(report先未設定で実質無効)から強制モードへ移行し、`script_src`から包括的な`:https`許可を除去する。これによりXSSが発生しても外部スクリプト読み込み・インライン実行がブラウザレベルでブロックされる。強制化の障害だったインラインJS 6箇所をStimulus化した。

Closes #511

## 対応

**インラインJSの全廃(挙動不変):**
- `auth_method_controller`新設: 登録画面のパスキー/パスワード切替(インライン`<script>`+`onclick`×2を置換。ラジオ・パスワード欄はStimulusターゲット化)
- `clipboard_controller`新設: メモ共有URLコピーの`onclick`を置換
- `video_play_controller`新設: スターター動画×2の再生ボタン`onclick`を置換
- Google Fonts非同期CSSの`onload="this.media='all'"`を`data-media-onload`属性+application.tsの`activateAsyncStylesheets`に置換(noscriptフォールバック維持)

**CSP強化:**
- `script_src`: `:self` + `assets.bokrium.com` のみに(`:https`包括除去、`unsafe_inline`なし)
- `style_src`: `:https`包括を除去し `:self, :unsafe_inline` + assets/fonts.googleapisに(style属性・`<style>`ブロック・Turboプログレスバーが必要とするため。script側が絞られていれば実害は限定的)
- `content_security_policy_report_only = true` を削除 → **強制モード**
- 事前確認済み: StripeはサーバーサイドリダイレクトのCheckoutのみでjs.stripe.com不使用、ActionCable未使用、フロントの外部fetchなし

## 影響範囲

- 全ページのCSPヘッダが`Content-Security-Policy`(強制)になる
- 対象6箇所のUI挙動は不変(登録画面の認証切替・共有URLコピー・動画再生・フォント非同期読み込み)
- 想定外のインラインJSが今後追加されるとブラウザでブロックされる(=退行を防ぐガードにもなる)

## Test plan

- [x] CSPヘッダのrequest spec追加(強制モード・script-src内容・Report-Only不在)
- [x] インラインJS残存ゼロをgrepで確認(`<script`/`on*=`/`javascript:`)
- [x] `npm run typecheck` / `bundle exec rubocop` / `bundle exec brakeman`(0 warnings)
- [x] `docker compose run --rm web-test` — system spec(メモモーダル・画像・確認フロー等)がヘッドレスChromeでCSP強制下で全通過 = 実動作検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)
