### PR TITLE
Chore: Dependabotアラート17件(high 3)のnpm依存を更新する

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,8 +21,8 @@
         "@types/sortablejs": "^1.15.9",
         "@zxing/browser": "^0.1.5",
         "bootstrap": "^5.3.5",
-        "dompurify": "^3.3.1",
-        "markdown-it": "^14.1.1",
+        "dompurify": "^3.4.11",
+        "markdown-it": "^14.2.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "sortablejs": "^1.15.7",
@@ -36,7 +36,7 @@
         "playwright": "1.58.2",
         "sass": "^1.89.2",
         "typescript": "^6.0.3",
-        "vite": "^7.3.0",
+        "vite": "^7.3.5",
         "vite-plugin-ruby": "^5.1.1"
       },
       "engines": {
@@ -885,9 +885,15 @@
       "license": "MIT"
     },
     "node_modules/@excalidraw/excalidraw/node_modules/nanoid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
-      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
       "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -950,9 +956,9 @@
       }
     },
     "node_modules/@excalidraw/mermaid-to-excalidraw/node_modules/nanoid": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
-      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.9.tgz",
+      "integrity": "sha512-Aooyr6MXU6HpvvWXKoVoXwKMs/KyVakWwg7xQfv5/S/RIgJMy0Ifa45H9qqYy7pTCszrHzP21Uk4PZq2HpEM8Q==",
       "funding": [
         {
           "type": "github",
@@ -964,7 +970,7 @@
         "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^14 || ^16 || >=18"
+        "node": "^18 || >=20"
       }
     },
     "node_modules/@excalidraw/random-username": {
@@ -3758,9 +3764,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
-      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -4145,9 +4151,19 @@
       "license": "MIT"
     },
     "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
@@ -4160,9 +4176,9 @@
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -4178,14 +4194,24 @@
       "license": "MIT"
     },
     "node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"
@@ -4319,25 +4345,6 @@
       "dependencies": {
         "glur": "^1.1.2",
         "object-assign": "^4.1.1"
-      }
-    },
-    "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/node-addon-api": {
@@ -4564,6 +4571,25 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/prosemirror-changeset": {
@@ -5303,13 +5329,13 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "@types/sortablejs": "^1.15.9",
     "@zxing/browser": "^0.1.5",
     "bootstrap": "^5.3.5",
-    "dompurify": "^3.3.1",
-    "markdown-it": "^14.1.1",
+    "dompurify": "^3.4.11",
+    "markdown-it": "^14.2.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "sortablejs": "^1.15.7",
@@ -40,7 +40,12 @@
     "playwright": "1.58.2",
     "sass": "^1.89.2",
     "typescript": "^6.0.3",
-    "vite": "^7.3.0",
+    "vite": "^7.3.5",
     "vite-plugin-ruby": "^5.1.1"
+  },
+  "overrides": {
+    "lodash-es": "^4.18.0",
+    "nanoid@^3.0.0": "3.3.8",
+    "nanoid@^4.0.0": "5.0.9"
   }
 }


### PR DESCRIPTION
## 概要

Dependabotアラート17件(high 3 / medium 11 / low 3、全てnpm)を解消する。

Closes #515

## 対応

- 直接依存のレンジを修正版以上へ更新: `vite ^7.3.5`(→7.3.6) / `dompurify ^3.4.11` / `markdown-it ^14.2.0`(→14.3.0)
- 間接依存は `npm update` でlockfileを更新: `linkify-it 5.0.2`
- 依存元が脆弱版を固定しているものは `overrides` で解決:
  - `lodash-es ^4.18.0`(chevrotain@11.0.3 が 4.17.21 を完全固定)
  - `nanoid@^3.0.0 → 3.3.8`(@excalidraw/excalidraw が 3.3.3 を完全固定)
  - `nanoid@^4.0.0 → 5.0.9`(@excalidraw/mermaid-to-excalidraw が 4.0.2 を完全固定。4.x系に修正版が存在せず、5.0.9はAPI互換)

`npm audit`: **0 vulnerabilities**

## 影響範囲

- フロントエンドバンドルのみ(Ruby側変更なし)
- いずれもsemverパッチ〜マイナー相当の更新。nanoidのみメジャーを跨ぐが、`nanoid()` / `customAlphabet` のAPIは4.x/5.xで互換

## Test plan

- [x] `npm audit` → 0 vulnerabilities
- [x] `npm run typecheck`
- [x] `npm run build`(vite 7.3.6でビルド成功)
- [x] `bundle exec rubocop` / `bundle exec brakeman -q`
- [x] `docker compose run --rm web-test`(379 examples, 0 failures, 2 pending=既存)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 一部のライブラリとビルド関連の依存関係を更新しました。
  * 依存関係の解決方法を調整し、安定性向上と将来の互換性確保を行いました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->