### PR TITLE
Security: 小粒な穴の一括対応(認証漏れ・paranoid・SVG禁止・GET副作用・レート制限)

### DIFF
--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -1,4 +1,5 @@
 class ImagesController < ApplicationController
+  before_action :authenticate_user!
   before_action :set_book
 
   def create

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,4 +1,7 @@
 class SearchController < ApplicationController
+  # 外部書誌APIへのプロキシなので、未認証の連打で外部APIのquotaを食い潰されないようにする
+  rate_limit to: 30, within: 1.minute
+
   SEARCH_TYPES = %w[isbn author title].freeze
   APIs = %i[ OpenBdService RakutenService GoogleBooksService NdlService ]
             .map { |name| BookApis.const_get(name) }

--- a/app/controllers/user_tags_controller.rb
+++ b/app/controllers/user_tags_controller.rb
@@ -1,4 +1,5 @@
 class UserTagsController < ApplicationController
+  before_action :authenticate_user!
   before_action :set_user_tag, only: [ :edit, :update, :destroy ]
 
   def create

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Users::RegistrationsController < Devise::RegistrationsController
+  rate_limit to: 10, within: 3.minutes, only: :create
+
   before_action :configure_sign_up_params, only: [ :create ]
   # before_action :configure_account_update_params, only: [:update]
 

--- a/app/controllers/users/webauthn_sessions_controller.rb
+++ b/app/controllers/users/webauthn_sessions_controller.rb
@@ -2,6 +2,8 @@
 
 module Users
   class WebauthnSessionsController < ApplicationController
+    rate_limit to: 10, within: 3.minutes, only: :create
+
     # ログイン開始（challenge 生成）
     def new
       options = WebAuthn::Credential.options_for_get(

--- a/app/models/concerns/upload_validations.rb
+++ b/app/models/concerns/upload_validations.rb
@@ -6,17 +6,18 @@ module UploadValidations
   def validate_upload_format(attachment, attribute_name)
     return unless attachment.attached?
 
-    allowed_extensions = %w[jpg jpeg png gif webp svg]
-    allowed_content_types = %w[image/jpeg image/png image/gif image/webp image/svg+xml]
+    # SVGはscriptを内包できる(stored XSSベクタ)ため許可しない
+    allowed_extensions = %w[jpg jpeg png gif webp]
+    allowed_content_types = %w[image/jpeg image/png image/gif image/webp]
 
     extension = attachment.filename.extension_without_delimiter&.downcase
     content_type = attachment.content_type
 
     # content_type が許可されていれば、拡張子が無くても許可する
     if !allowed_content_types.include?(content_type)
-      errors.add(attribute_name, " : 許可されていない形式です（jpg, png, gif, webp, svg）")
+      errors.add(attribute_name, " : 許可されていない形式です（jpg, png, gif, webp）")
     elsif extension.present? && !allowed_extensions.include?(extension)
-      errors.add(attribute_name, " : ファイル拡張子が不正です（jpg, png, gif, webp, svg）")
+      errors.add(attribute_name, " : ファイル拡張子が不正です（jpg, png, gif, webp）")
     end
 
     if attachment.blob.byte_size > MAX_UPLOAD_SIZE

--- a/app/views/donations/index.html.erb
+++ b/app/views/donations/index.html.erb
@@ -43,7 +43,7 @@
         <p class="text-muted mb-4">
           月々300円から、継続的な応援ができます。
         </p>
-        <%= link_to "月々300円で応援する", create_subscrption_path,
+        <%= button_to "月々300円で応援する", create_subscription_path,
           class: "btn btn-lg btn-primary px-5 py-3 shadow rounded-pill fs-5" %>
         <p class="text-muted small mt-3">
           ※いつでも解約可能・支援は任意です。

--- a/app/views/subscriptions/create.html.erb
+++ b/app/views/subscriptions/create.html.erb
@@ -1,2 +1,0 @@
-<h1>Subscriptions#create</h1>
-<p>Find me in app/views/subscriptions/create.html.erb</p>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -3,6 +3,9 @@
 Devise.setup do |config|
   config.mailer_sender = "Bokrium <support@bokrium.com>"
 
+  # パスワードリセット等のレスポンスからメールアドレスの存在有無を判別できないようにする
+  config.paranoid = true
+
   require "devise/orm/active_record"
 
   config.maximum_attempts = 10

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -126,7 +126,7 @@ Rails.application.routes.draw do
     post :stripe, to: "stripe#create"
     post :email_notifications, to: "email_notifications#create"
   end
-  get "subscriptions/create", as: :create_subscrption
+  post "subscriptions", to: "subscriptions#create", as: :create_subscription
   post "subscription/cancel", to: "subscriptions#cancel", as: :cancel_subscription
 end
 

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe Image, type: :model do
+  describe "アップロード形式のバリデーション" do
+    it "PNGは許可される" do
+      image = FactoryBot.build(:image)
+      expect(image).to be_valid
+    end
+
+    it "SVGは拒否される(stored XSSベクタ)" do
+      image = FactoryBot.build(:image)
+      image.image_s3.attach(
+        io: StringIO.new('<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>'),
+        filename: "evil.svg",
+        content_type: "image/svg+xml"
+      )
+      expect(image).not_to be_valid
+      expect(image.errors[:image_s3].join).to include("許可されていない形式")
+    end
+
+    it "content_typeをimage/pngと偽装したSVGも拒否される" do
+      image = FactoryBot.build(:image)
+      image.image_s3.attach(
+        io: StringIO.new("<svg/>"),
+        filename: "evil.svg",
+        content_type: "image/png"
+      )
+      expect(image).not_to be_valid
+      expect(image.errors[:image_s3]).to be_present
+    end
+  end
+end

--- a/spec/requests/images_spec.rb
+++ b/spec/requests/images_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe "Images", type: :request do
+  let(:user) { FactoryBot.create(:user) }
+  let(:book) { FactoryBot.create(:book, user: user) }
+
+  describe "未ログイン時" do
+    it "POST /books/:book_id/images はサインインへリダイレクトする" do
+      post book_images_path(book), params: { image: { image_s3: "dummy" } }
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it "DELETE /books/:book_id/images/:id はサインインへリダイレクトする" do
+      image = FactoryBot.create(:image, book: book)
+      delete book_image_path(book, image)
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+
+  describe "ログイン時" do
+    before { sign_in user }
+
+    it "画像を作成できる" do
+      expect {
+        post book_images_path(book), params: {
+          image: { image_s3: fixture_file_upload("sample.png", "image/png") }
+        }
+      }.to change(Image, :count).by(1)
+      expect(response).to redirect_to(book_path(book))
+    end
+  end
+end

--- a/spec/requests/subscriptions_spec.rb
+++ b/spec/requests/subscriptions_spec.rb
@@ -1,10 +1,17 @@
-# require 'rails_helper'
+require 'rails_helper'
 
-# RSpec.describe "Subscriptions", type: :request do
-#   describe "GET /create" do
-#     it "returns http success" do
-#       get "/subscriptions/create"
-#       expect(response).to have_http_status(:success)
-#     end
-#   end
-# end
+RSpec.describe "Subscriptions", type: :request do
+  describe "POST /subscriptions" do
+    it "未ログイン時はサインインへリダイレクトする(Stripeには到達しない)" do
+      post create_subscription_path
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+
+  describe "GET /subscriptions/create" do
+    it "副作用のある旧GETルートは廃止されている" do
+      get "/subscriptions/create"
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/requests/user_tags_spec.rb
+++ b/spec/requests/user_tags_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe "UserTags", type: :request do
+  let(:user) { FactoryBot.create(:user) }
+
+  describe "未ログイン時" do
+    it "POST /user_tags はサインインへリダイレクトする" do
+      post user_tags_path, params: { user_tag: { name: "小説" } }
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+
+  describe "ログイン時" do
+    before { sign_in user }
+
+    it "タグを作成できる" do
+      expect {
+        post user_tags_path, params: { user_tag: { name: "小説" } }
+      }.to change(user.user_tags, :count).by(1)
+    end
+  end
+end

--- a/spec/requests/users/passwords_spec.rb
+++ b/spec/requests/users/passwords_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe "Users::Passwords", type: :request do
+  describe "POST /users/password (paranoidモード)" do
+    let(:user) { FactoryBot.create(:user) }
+
+    it "存在するメールアドレスでも存在しないメールアドレスでも同じ応答になる(ユーザー列挙対策)" do
+      post user_password_path, params: { user: { email: user.email } }
+      existing_redirect = response.redirect_url
+      existing_flash = flash[:notice]
+
+      post user_password_path, params: { user: { email: "no-such-user@example.com" } }
+      expect(response.redirect_url).to eq(existing_redirect)
+      expect(flash[:notice]).to eq(existing_flash)
+    end
+
+    it "存在しないメールアドレスでもエラーにならずリダイレクトする" do
+      post user_password_path, params: { user: { email: "no-such-user@example.com" } }
+      expect(response).to have_http_status(:redirect)
+    end
+  end
+end


### PR DESCRIPTION
## 概要

全体レビュー(2026-07-05)で見つかったセキュリティ小粒の穴とレート制限の欠落をまとめて塞ぐ。

Closes #516

## 対応

### 認証漏れ(500 → 302)
- `ImagesController` / `UserTagsController` に `before_action :authenticate_user!` を追加。未ログインPOSTは `current_user.books.find` のnilエラーで500になっていた(認可自体はcurrent_userスコープで守られており情報漏えいはなし)

### Devise paranoidモード
- `config.paranoid = true` を設定。パスワードリセット等のレスポンスからメールアドレスの存在有無を判別できないようにする(ユーザー列挙対策)
- lockable系specはDB状態・メール本文のみ検証しているため影響なし(フルスイートで確認済み)

### SVGアップロード禁止(stored XSSベクタ)
- `upload_validations.rb` の許可リストから `svg` / `image/svg+xml` を除去(jpg/png/gif/webpのみに)
- 利用箇所はImage / Book表紙 / HandwrittenNoteサムネイルの3モデル。手書きノートサムネイルは `exportToBlob(mimeType: "image/png")` でPNG固定のため影響なし
- content_typeを`image/png`と偽装したSVGもActiveStorage(Marcel)のsniffで正しく拒否されることをspecで確認

### GET副作用の廃止
- `GET /subscriptions/create`(Stripe Checkoutセッション作成)を `POST /subscriptions` へ変更。GETはプリフェッチ/クローラーに踏まれ得る
- 参照元の寄付ページを `link_to` → `button_to` に変更、path helperのtypo(`create_subscrption`)も修正
- `create` は常にStripeへリダイレクトするため、死んでいたscaffoldビュー `subscriptions/create.html.erb` を削除

### レート制限の追加(既存のsessions/passwordsと同じ流儀)

| 対象 | 制限 |
|------|------|
| 新規登録 `Users::RegistrationsController#create` | 10回 / 3分 |
| パスキーログイン `Users::WebauthnSessionsController#create` | 10回 / 3分 |
| 外部書誌APIプロキシ `SearchController`(全action・未認証で叩ける) | 30回 / 1分 |

※ rate_limitのrequest specはtest環境が `:null_store` のため書けない(既存のsessions側と同じ扱い)

## 影響範囲

- 通常操作への影響なし。未ログインPOSTが500→302、SVGアップロードのみ新規拒否、寄付ページのリンクがボタン(POSTフォーム)に
- レート制限超過時は429(既存のログイン制限と同挙動)
- paranoid化によりパスワードリセット等のflash文言が汎用文言に変わる

## Test plan

- [x] 新規spec 12件: images/user_tagsの認証(302)、サインイン済みのcreate成功、POST /subscriptions認証、旧GETルート404、SVG拒否(素直な形式+content_type偽装)、paranoid同一応答
- [x] `bundle exec rubocop` / `bundle exec brakeman -q` / `npm run typecheck`
- [x] `docker compose run --rm web-test`(391 examples, 0 failures, 2 pending=既存)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
